### PR TITLE
Fix bugs to convert raw AHI observations from AWS in HSD format to IODA-v2

### DIFF
--- a/obs2ioda-v2/src/Makefile
+++ b/obs2ioda-v2/src/Makefile
@@ -15,7 +15,7 @@ FC = ifort
 #BUFR_LIB = -L/glade/u/home/hclin/extlib/intel -lbufr
 #FFLAGS = -mcmodel medium # needed for intel error message "failed to convert GOTPCREL relocation"
 BUFR_LIB = -L/glade/p/mmm/parc/ivette/pandac/converters/WRFDA_3DVAR_dmpar/var/external/bufr -lbufr #-L/glade/u/home/hclin/extlib/intel -lbufr
-FFLAGS = -mcmodel medium -g -traceback -debug all -check all # needed for intel error message "failed to convert GOTPCREL relocation"
+FFLAGS = -mcmodel medium # needed for intel error message "failed to convert GOTPCREL relocation" # -g -traceback -debug all -check all
 
 LIBS = -L$(NETCDF)/lib -lnetcdff -lnetcdf ${BUFR_LIB}
 INCS = -I$(NETCDF)/include

--- a/obs2ioda-v2/src/define_mod.f90
+++ b/obs2ioda-v2/src/define_mod.f90
@@ -418,4 +418,23 @@ subroutine set_brit_obserr(name_inst, nchan, obserrors)
 
 end subroutine set_brit_obserr
 
+subroutine set_ahi_obserr(name_inst, nchan, obserrors)
+   implicit none
+
+   character(len=*), intent(in)  :: name_inst  ! instrument name
+   integer(i_kind),  intent(in)  :: nchan      ! channel number
+   real(r_kind),     intent(out) :: obserrors(nchan)
+   obserrors(:) = missing_r
+   if ( name_inst(1:3) == 'ahi' ) then
+      select case ( trim(name_inst) )
+         case ( 'ahi_himawari8' )
+            obserrors = (/ 2.2, 3.0, 2.5, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 /)
+         case default
+            return
+      end select
+   else
+      return
+   end if
+end subroutine set_ahi_obserr
+
 end module define_mod

--- a/obs2ioda-v2/src/hsd.f90
+++ b/obs2ioda-v2/src/hsd.f90
@@ -444,6 +444,7 @@ do iband = 1, nband
       offset = flength - (npix * nlin *2)
       ! Reposition the file to the offset value for reading
       call fseek(iunit, offset, 0, rvalue)
+      read(iunit)idata(:)
 
       startLine = header%segm%startLineNo
       endLine = startLine + header%data%nLin - 1

--- a/obs2ioda-v2/src/hsd.f90
+++ b/obs2ioda-v2/src/hsd.f90
@@ -250,7 +250,7 @@ integer(i_kind) :: count, i, ii, jj, ij, iv
 integer(i_kind) :: iband, isegm
 integer(i_kind) :: ierr
 integer(i_kind) :: nlocs, nvars, iloc
-integer(i_kind) :: ihh, imm, idd, jday, flength, rvalue
+integer(i_kind) :: ihh, imm, idd, jday, flength, rvalue, offset
 integer(i_kind) :: iunit = 21
 real(r_double)  :: lon, lat
 real(r_double)  :: radiance, tbb
@@ -308,44 +308,142 @@ do iband = 1, nband
    do isegm = 1, nsegm
       ifile = isegm + (iband-1) * nsegm
       if ( .not. fexist(ifile) ) cycle
-      open(newunit=iunit, file=trim(fnames(ifile)), form='unformatted', action='read', access='stream', status='old', convert='little_endian')
+      open(iunit, file=trim(fnames(ifile)), form='unformatted', action='read', access='stream', status='old', convert='little_endian')
       print*,'Reading from ', trim(fnames(ifile))
 
-      read(iunit) header%basic%headerNum, header%basic%blockLen, header%basic%numHeader, header%basic%byteOrder, header%basic%satName, header%basic%procCenter, header%basic%obsArea, header%basic%dummy2, header%basic%hhnn, header%basic%obsStartTime, header%basic%obsEndTime, header%basic%fileCreateTime, header%basic%totalHeaderLen, header%basic%dataLen, header%basic%qcflag1, header%basic%qcflag2, header%basic%qcflag3, header%basic%qcflag4, header%basic%version, header%basic%fileName, header%basic%dummy40
-      read(iunit) header%data%headerNum, header%data%blockLen, header%data%bitPix, header%data%nPix, header%data%nLin, header%data%compression, header%data%dummy40
-      read(iunit) header%proj%headerNum,header%proj%blockLen,header%proj%subLon,header%proj%cfac,header%proj%lfac,header%proj%coff,header%proj%loff,header%proj%satDis,header%proj%eqtrRadius,header%proj%polrRadius,header%proj%projParam1,header%proj%projParam2,header%proj%projParam3,header%proj%projParamSd,header%proj%resampleKind,header%proj%resampleSize,header%proj%dummy40
-      read(iunit) header%navi%headerNum, header%navi%blockLen, header%navi%navTime, header%navi%sspLon, header%navi%sspLat, header%navi%satDis, header%navi%nadirLon, header%navi%nadirLat, header%navi%sunPos_x, header%navi%sunPos_y, header%navi%sunPos_z, header%navi%moonPos_x, header%navi%moonPos_y, header%navi%moonPos_z, header%navi%dummy40
-      read(iunit) header%calib%headerNum, header%calib%blockLen, header%calib%bandNo, header%calib%waveLen, header%calib%bitPix, header%calib%errorCount, header%calib%outCount, header%calib%gain_cnt2rad, header%calib%cnst_cnt2rad, header%calib%rad2btp_c0, header%calib%rad2btp_c1, header%calib%rad2btp_c2, header%calib%btp2rad_c0, header%calib%btp2rad_c1, header%calib%btp2rad_c2, header%calib%lightSpeed, header%calib%planckConst, header%calib%bolzConst, header%calib%dummy40
-      read(iunit) header%interCalib%headerNum,  header%interCalib%blockLen, header%interCalib%dummy256
-      read(iunit) header%segm%headerNum, header%segm%blockLen, header%segm%totalSegNum, header%segm%segSeqNo, header%segm%startLineNo, header%segm%dummy40
-      read(iunit) header%navicorr%headerNum, header%navicorr%blockLen, header%navicorr%RoCenterColumn, header%navicorr%RoCenterLine, header%navicorr%RoCorrection, header%navicorr%correctNum
+      read(iunit) header%basic%headerNum, &
+                  header%basic%blockLen, &
+                  header%basic%numHeader, &
+                  header%basic%byteOrder, &
+                  header%basic%satName, &
+                  header%basic%procCenter, &
+                  header%basic%obsArea, &
+                  header%basic%dummy2, &
+                  header%basic%hhnn, &
+                  header%basic%obsStartTime, &
+                  header%basic%obsEndTime, &
+                  header%basic%fileCreateTime, &
+                  header%basic%totalHeaderLen, &
+                  header%basic%dataLen, &
+                  header%basic%qcflag1, &
+                  header%basic%qcflag2, &
+                  header%basic%qcflag3, &
+                  header%basic%qcflag4, &
+                  header%basic%version, &
+                  header%basic%fileName, &
+                  header%basic%dummy40
+      read(iunit) header%data%headerNum, &
+                  header%data%blockLen,&
+                  header%data%bitPix, &
+                  header%data%nPix, &
+                  header%data%nLin, &
+                  header%data%compression, &
+                  header%data%dummy40
+      read(iunit) header%proj%headerNum, &
+                  header%proj%blockLen, &
+                  header%proj%subLon, &
+                  header%proj%cfac, &
+                  header%proj%lfac, &
+                  header%proj%coff, &
+                  header%proj%loff, &
+                  header%proj%satDis, &
+                  header%proj%eqtrRadius, &
+                  header%proj%polrRadius, &
+                  header%proj%projParam1, &
+                  header%proj%projParam2, &
+                  header%proj%projParam3, &
+                  header%proj%projParamSd, &
+                  header%proj%resampleKind, &
+                  header%proj%resampleSize, &
+                  header%proj%dummy40
+      read(iunit) header%navi%headerNum, &
+                  header%navi%blockLen, &
+                  header%navi%navTime, &
+                  header%navi%sspLon, &
+                  header%navi%sspLat, &
+                  header%navi%satDis, &
+                  header%navi%nadirLon, &
+                  header%navi%nadirLat, &
+                  header%navi%sunPos_x, &
+                  header%navi%sunPos_y, &
+                  header%navi%sunPos_z, &
+                  header%navi%moonPos_x, &
+                  header%navi%moonPos_y, &
+                  header%navi%moonPos_z, &
+                  header%navi%dummy40
+      read(iunit) header%calib%headerNum, &
+                  header%calib%blockLen, &
+                  header%calib%bandNo, &
+                  header%calib%waveLen, &
+                  header%calib%bitPix, &
+                  header%calib%errorCount, &
+                  header%calib%outCount, &
+                  header%calib%gain_cnt2rad, &
+                  header%calib%cnst_cnt2rad, &
+                  header%calib%rad2btp_c0, &
+                  header%calib%rad2btp_c1, &
+                  header%calib%rad2btp_c2, &
+                  header%calib%btp2rad_c0, &
+                  header%calib%btp2rad_c1, &
+                  header%calib%btp2rad_c2, &
+                  header%calib%lightSpeed, &
+                  header%calib%planckConst, &
+                  header%calib%bolzConst, &
+                  header%calib%dummy40
+      read(iunit) header%interCalib%headerNum, &
+                  header%interCalib%blockLen, &
+                  header%interCalib%dummy256
+      read(iunit) header%segm%headerNum, &
+                  header%segm%blockLen, &
+                  header%segm%totalSegNum, &
+                  header%segm%segSeqNo, &
+                  header%segm%startLineNo, &
+                  header%segm%dummy40
+      read(iunit) header%navicorr%headerNum, &
+                  header%navicorr%blockLen, &
+                  header%navicorr%RoCenterColumn, &
+                  header%navicorr%RoCenterLine, &
+                  header%navicorr%RoCorrection, &
+                  header%navicorr%correctNum
       if ( header%navicorr%correctNum > 0 ) then
          numCorrect = header%navicorr%correctNum
          allocate(header%navicorr%lineNo(numCorrect))
          allocate(header%navicorr%columnShift(numCorrect))
          allocate(header%navicorr%lineShift(numCorrect))
       end if
-      read(iunit) header%navicorr%lineNo(numCorrect), header%navicorr%columnShift(numCorrect), header%navicorr%lineShift(numCorrect), header%navicorr%dummy40
+      read(iunit) header%navicorr%lineNo(numCorrect), &
+                  header%navicorr%columnShift(numCorrect), &
+                  header%navicorr%lineShift(numCorrect), &
+                  header%navicorr%dummy40
       rewind(iunit)
-      read(iunit) header%obstime%headerNum, header%obstime%blockLen, header%obstime%obsNum
+      read(iunit) header%obstime%headerNum, &
+                  header%obstime%blockLen, &
+                  header%obstime%obsNum
       if ( header%obsTime%obsNum > 0 ) then
          numObs = header%obsTime%obsNum
          allocate(header%obsTime%lineNo(numObs))
          allocate(header%obsTime%obsMJD(numObs))
       end if
-      read(iunit) header%obstime%lineNo, header%obstime%obsMJD, header%obstime%dummy40
-      read(iunit) header%error%headerNum, header%error%blockLen, header%error%errorNum, header%error%dummy40
-      read(iunit) header%dummy%headerNum, header%dummy%blockLen, header%dummy%dummy256
-
+      read(iunit) header%obstime%lineNo, &
+                  header%obstime%obsMJD, &
+                  header%obstime%dummy40
+      read(iunit) header%error%headerNum, &
+                  header%error%blockLen, &
+                  header%error%errorNum, &
+                  header%error%dummy40
+      read(iunit) header%dummy%headerNum, &
+                  header%dummy%blockLen, &
+                  header%dummy%dummy256
       npix = header%data%nPix
       nlin = header%data%nLin
       ntotal = npix * nlin
       allocate(idata(ntotal))
 
       inquire(file=trim(fnames(ifile)), size=flength)
-      flength = flength - (npix * nlin *2)
-      call fseek(iunit, flength, 0, rvalue)
-      read(iunit) idata(:)
+      ! Offset relative to the beginning of the file
+      offset = flength - (npix * nlin *2)
+      ! Reposition the file to the offset value for reading
+      call fseek(iunit, offset, 0, rvalue)
 
       startLine = header%segm%startLineNo
       endLine = startLine + header%data%nLin - 1
@@ -408,6 +506,7 @@ do iband = 1, nband
 !print*,iband+6, ij, ii, jj, count, tbb, lon, lat, solzen(ipixel, iline), satzen(ipixel, iline)
                brit(ipixel, iline, iband) = tbb
             end if
+
          end do ! pixel
       end do ! line
 

--- a/obs2ioda-v2/src/ncio_mod.f90
+++ b/obs2ioda-v2/src/ncio_mod.f90
@@ -7,7 +7,7 @@ use define_mod, only: nobtype, nvar_info, n_ncdim, n_ncgrp, nstring, ndatetime, 
    xdata, itrue, ifalse, vflag, ninst, inst_list, write_nc_conv, write_nc_radiance, &
    write_nc_radiance_geo, ninst_geo, geoinst_list, &
    var_tb, nsen_info, type_var_info, type_sen_info, dim_var_info, dim_sen_info, &
-   unit_var_met, iflag_conv, iflag_radiance, set_brit_obserr
+   unit_var_met, iflag_conv, iflag_radiance, set_brit_obserr, set_ahi_obserr
 use netcdf_mod, only: open_netcdf_for_write, close_netcdf, &
    def_netcdf_dims, def_netcdf_grp, def_netcdf_var, def_netcdf_end, &
    put_netcdf_var, get_netcdf_dims
@@ -89,7 +89,11 @@ subroutine write_obs (filedate, write_opt, outdir, itim)
          allocate (ichan(xdata(ityp,itim)%nvars))
          ichan(:) = xdata(ityp,itim)%xseninfo_int(:,iv)
          allocate (obserr(xdata(ityp,itim)%nvars))
-         call set_brit_obserr(inst_list(ityp), xdata(ityp,itim)%nvars, obserr)
+         if  ( geoinst_list(ityp) == 'ahi_himawari8' ) then
+             call set_ahi_obserr(geoinst_list(ityp), xdata(ityp,itim)%nvars, obserr)
+         else
+             call set_brit_obserr(inst_list(ityp), xdata(ityp,itim)%nvars, obserr)
+         end if
       end if
       write(*,*) '--- writing ', trim(ncfname)
       call open_netcdf_for_write(trim(ncfname),ncfileid)


### PR DESCRIPTION
**Description**
This PR fixes some bugs found to convert raw AHI observations from the AWS cloud in Himawari Standard Data (HSD) format to the IODA-v2 needed in `mpas-jedi`. It was added the capability to read files with segment number 01, which corresponds to the no segment division of HSD data. The reading of the variables was modified to read each one explicitly since otherwise it was not working properly (not sure why). Specifically the way the variable `idata`, which is the count (total number of pixels that results from multiplying the number of columns by the number of lines) needed for the radiance calculation is also modified. This modification results in the correct calculation of the radiance and then the brightness temperature. In addition, the variable for the `dateTime` in `epochtime` type was allocated since that was missing. The observation error was also added following the values used in GSI (https://www.nco.ncep.noaa.gov/pmb/codes/nwprod/gfs.v16.2.2/fix/fix_gsi/global_satinfo.txt) for clear-sky and a bug in the function that sets the errors was fixed as well.

**Closes** 
Issue https://github.com/NCAR/obs2ioda/issues/2