### PR TITLE
Add superobbing capability for AHI observations

### DIFF
--- a/goes_abi/src/Makefile
+++ b/goes_abi/src/Makefile
@@ -11,7 +11,7 @@
 #INTEL compiler
 #--------------
 FC = ifort
-FFLAGS = -mcmodel medium -g -traceback -debug all -check all # needed for intel error message "failed to convert GOTPCREL relocation"
+FFLAGS = -mcmodel medium # needed for intel error message "failed to convert GOTPCREL relocation" #-g -traceback -debug all -check all
 
 LIBS = -L$(NETCDF)/lib -lnetcdff -lnetcdf
 INCS = -I$(NETCDF)/include

--- a/obs2ioda-v2/src/hsd.f90
+++ b/obs2ioda-v2/src/hsd.f90
@@ -561,7 +561,6 @@ if ( do_superob ) then
         if ( satzen(ix,iy)  > 65.0 ) cycle valid_loop
         if ( all(brit(ix,iy,:) < 0.0) ) cycle
         nlocs = nlocs + 1
-        print*, 'ix,iy, nlocs = ', ix,iy,nlocs
     end do valid_loop
   end do
 

--- a/obs2ioda-v2/src/hsd.f90
+++ b/obs2ioda-v2/src/hsd.f90
@@ -40,6 +40,7 @@ integer(i_kind), parameter :: nsegm = 10  ! number of segment
 real(r_single)  :: longitude(npixel, nline)
 real(r_single)  :: latitude(npixel, nline)
 real(r_single)  :: brit(npixel, nline, nband)
+real(r_kind)    :: bt_sup(npixel, nline, nband)   ! superobbed brightness temperature(superobpixel, superobline, nband)
 real(r_single)  :: solzen(npixel, nline)
 real(r_single)  :: satzen(npixel, nline)
 logical         :: valid(npixel, nline)
@@ -222,12 +223,14 @@ real(r_double), parameter :: rad2deg = 180.0/pi
 
 contains
 
-subroutine read_HSD(ccyymmddhhnn, inpdir)
+subroutine read_HSD(ccyymmddhhnn, inpdir, do_superob, superob_halfwidth)
 
 implicit none
 
 character(len=12), intent(in) :: ccyymmddhhnn
 character(len=*),  intent(in) :: inpdir
+logical,           intent(in) :: do_superob
+integer(i_kind),   intent(in) :: superob_halfwidth
 
 character(len=1051) :: dummy1051
 character(len=1)    :: dummy1
@@ -246,7 +249,7 @@ integer(i_kind) :: numCorrect
 integer(i_kind) :: numObs
 integer(i_kind) :: ipixel, iline
 integer(i_kind) :: startLine, endLine
-integer(i_kind) :: count, i, ii, jj, ij, iv
+integer(i_kind) :: radcount, i, ii, jj, ij, iv
 integer(i_kind) :: iband, isegm
 integer(i_kind) :: ierr
 integer(i_kind) :: nlocs, nvars, iloc
@@ -256,15 +259,20 @@ real(r_double)  :: lon, lat
 real(r_double)  :: radiance, tbb
 real(r_double)  :: lon_sat, h_sat, r_eq
 integer(i_kind) :: nodivisionsegm = 1
+integer         :: superob_width ! Must be ≥ 0
+integer         :: first_boxcenter, last_boxcenter_x, last_boxcenter_y, box_bottom, box_upper, box_left, box_right
+integer         :: ibox, jbox, nkeep, ix, iy, tb, k
+real(r_kind)    :: temp1 = 0.0
 ! end of declaration
 continue
 
 longitude(:,:) = missing_r
 latitude(:,:)  = missing_r
-brit(:,:,:) = missing_r
-solzen(:,:) = missing_r
-satzen(:,:) = missing_r
-valid(:,:)  = .false.
+brit(:,:,:)    = missing_r
+bt_sup(:,:,:)  = missing_r
+solzen(:,:)    = missing_r
+satzen(:,:)    = missing_r
+valid(:,:)     = .false.
 
 ! construct file names
 nfile = nband * nsegm
@@ -490,12 +498,12 @@ do iband = 1, nband
                end if
             end if
 
-            count = idata(ij)
-            if ( count /= header%calib%outCount .and. &
-                 count /= header%calib%errorCount .and. &
-                 count > 0 ) then
+            radcount = idata(ij)
+            if ( radcount /= header%calib%outCount .and. &
+                 radcount /= header%calib%errorCount .and. &
+                 radcount > 0 ) then
                ! convert count value to radiance
-               radiance = count * header%calib%gain_cnt2rad + &
+               radiance = radcount * header%calib%gain_cnt2rad + &
                           header%calib%cnst_cnt2rad
                radiance = radiance * 1000000.0  ! [ W/(m^2 sr micro m)] => [ W/(m^2 sr m)]
                ! convert radiance to physical value
@@ -504,7 +512,7 @@ do iband = 1, nband
                call hisd_radiance_to_tbb(radiance, tbb)
                ! visible or near infrared band
                !  data->phys[kk] = header[n]->calib->rad2albedo * radiance
-!print*,iband+6, ij, ii, jj, count, tbb, lon, lat, solzen(ipixel, iline), satzen(ipixel, iline)
+!print*,iband+6, ij, ii, jj, radcount, tbb, lon, lat, solzen(ipixel, iline), satzen(ipixel, iline)
                brit(ipixel, iline, iband) = tbb
             end if
 
@@ -529,114 +537,281 @@ end do
 deallocate (fexist)
 deallocate (fnames)
 
-!print*,'transfering to xdata'
-
-nlocs = 0
-do jj = 1, nline , subsample
-   do ii = 1, npixel , subsample
-      if ( valid(ii,jj) ) then
-         nlocs = nlocs + 1
-      end if
-   end do
-end do
-
-allocate(xdata(1,1))
-nvars = nband
-xdata(1,1) % nlocs = nlocs
-xdata(1,1) % nrecs = nlocs
-xdata(1,1) % nvars = nvars
-! allocate and initialize
-allocate (xdata(1,1)%xinfo_float(nlocs, nvar_info))
-allocate (xdata(1,1)%xinfo_int  (nlocs, nvar_info))
-allocate (xdata(1,1)%xinfo_char (nlocs, nvar_info))
-allocate (xdata(1,1)%xseninfo_float(nlocs, nsen_info))
-allocate (xdata(1,1)%xseninfo_int  (nvars, nsen_info))
-allocate (xdata(1,1)%xinfo_int64(nlocs, nvar_info))
-xdata(1,1)%xinfo_float   (:,:) = missing_r
-xdata(1,1)%xinfo_int     (:,:) = missing_i
-xdata(1,1)%xinfo_char    (:,:) = ''
-xdata(1,1)%xseninfo_float(:,:) = missing_r
-xdata(1,1)%xseninfo_int  (:,:) = missing_i
-xdata(1,1)%xinfo_int64   (:,:) = 0
-if ( nvars > 0 ) then
-   allocate (xdata(1,1)%xfield(nlocs, nvars))
-   xdata(1,1)%xfield(:,:)%val = missing_r
-   xdata(1,1)%xfield(:,:)%qm  = missing_i
-   xdata(1,1)%xfield(:,:)%err = missing_r
-   allocate (xdata(1,1)%var_idx(nvars))
-   do iv = 1, nvars
-      xdata(1,1)%var_idx(iv) = iv
-   end do
-end if
-
 datetime = ccyy//'-'//mm//'-'//dd//'T'//hh//':'//nn//':00Z'
 read (ccyymmddhhnn,'(i4,4i2)') iyear, imonth, iday, ihour, imin
 isec = 0
 call get_julian_time(iyear, imonth, iday, ihour, imin, isec, gstime, epochtime)
 
-iloc = 0
-do jj = 1, nline, subsample
-   do ii = 1, npixel, subsample
-      if ( .not. valid(ii,jj) ) cycle
-      iloc = iloc + 1
+! do superobbing of ahi_himawari observations
+! npixel => x direction => nx
+! nline  => y direction => ny
+if ( do_superob ) then
+  nlocs = 0
+  superob_width = 2*superob_halfwidth+1
 
-!print*,ii,jj, latitude(ii,jj), longitude(ii,jj), satzen(ii,jj), solzen(ii,jj), brit(ii,jj,1)
+  ! start y_loop
 
-      do i = 1, nvar_info
-         if ( type_var_info(i) == nf90_int ) then
-         else if ( type_var_info(i) == nf90_float ) then
-            if ( trim(name_var_info(i)) == 'station_elevation' ) then
-               xdata(1,1)%xinfo_float(iloc,i) = missing_r
-            else if ( trim(name_var_info(i)) == 'latitude' ) then
-               xdata(1,1)%xinfo_float(iloc,i) = latitude(ii,jj)
-            else if ( trim(name_var_info(i)) == 'longitude' ) then
-               xdata(1,1)%xinfo_float(iloc,i) = longitude(ii,jj)
-            end if
-         else if ( type_var_info(i) == nf90_char ) then
-            if ( trim(name_var_info(i)) == 'datetime' ) then
-               xdata(1,1)%xinfo_char(iloc,i) = datetime
-            else if ( trim(name_var_info(i)) == 'station_id' ) then
-               xdata(1,1)%xinfo_char(iloc,i) = 'ahi_himawari8'
-            end if
-         else if ( type_var_info(i) == nf90_int64 ) then
-            if ( trim(name_var_info(i)) == 'dateTime' ) then
-               xdata(1,1)%xinfo_int64(iloc,i) = epochtime
-            end if
-         end if
-      end do
+  first_boxcenter = superob_halfwidth + 1
+  last_boxcenter_y = superob_width * (nline / superob_width) - superob_halfwidth
+  last_boxcenter_x = superob_width * (npixel / superob_width) - superob_halfwidth
 
-      do i = 1, nsen_info
-         if ( type_sen_info(i) == nf90_float ) then
-            if ( trim(name_sen_info(i)) == 'scan_position' ) then
-               xdata(1,1)%xseninfo_float(iloc,i) = ii
-            else if ( trim(name_sen_info(i)) == 'sensor_zenith_angle' ) then
-               xdata(1,1)%xseninfo_float(iloc,i) = satzen(ii,jj)
-            else if ( trim(name_sen_info(i)) == 'solar_zenith_angle' ) then
-               xdata(1,1)%xseninfo_float(iloc,i) = solzen(ii,jj)
-            else if ( trim(name_sen_info(i)) == 'sensor_azimuth_angle' ) then
-               xdata(1,1)%xseninfo_float(iloc,i) = missing_r
-            else if ( trim(name_sen_info(i)) == 'solar_azimuth_angle' ) then
-               xdata(1,1)%xseninfo_float(iloc,i) = missing_r
-            else if ( trim(name_sen_info(i)) == 'sensor_view_angle' ) then
-               !call calc_sensor_view_angle(trim(rlink%inst), rlink%scanpos, xdata(1,1)%xseninfo_float(iloc,i))
-               xdata(1,1)%xseninfo_float(iloc,i) = satzen(ii,jj)
-            end if
-!         else if ( type_sen_info(i) == nf90_int ) then
-!         else if ( type_sen_info(i) == nf90_char ) then
-         end if
-      end do
+  do iy=first_boxcenter, nline, superob_width
+    valid_loop:      do ix=first_boxcenter, npixel, superob_width
+        if ( .not. valid(ix,iy)) cycle
+        if ( satzen(ix,iy)  > 65.0 ) cycle valid_loop
+        if ( all(brit(ix,iy,:) < 0.0) ) cycle
+        nlocs = nlocs + 1
+        print*, 'ix,iy, nlocs = ', ix,iy,nlocs
+    end do valid_loop
+  end do
 
-      iv = ufo_vars_getindex(name_sen_info, 'sensor_channel')
-      xdata(1,1)%xseninfo_int(:,iv) = (/ 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 /)
+  write(0,*) 'nlocs = ', nlocs
+  if ( nlocs <= 0 ) then
+    return
+  end if
 
-      do i = 1, nvars
-         xdata(1,1)%xfield(iloc,i)%val = brit(ii,jj,i)
-         xdata(1,1)%xfield(iloc,i)%err = 1.0
-         !call set_brit_obserr(trim(rlink%inst), i, xdata(1,1)%xfield(iloc,i)%err)
-         xdata(1,1)%xfield(iloc,i)%qm  = 0
-      end do
-   end do
-end do
+  !print*,'transfering to xdata'
+
+  allocate(xdata(1,1))
+  nvars = nband
+  xdata(1,1) % nlocs = nlocs
+  xdata(1,1) % nrecs = nlocs
+  xdata(1,1) % nvars = nvars
+  ! allocate and initialize
+  allocate (xdata(1,1)%xinfo_float(nlocs, nvar_info))
+  allocate (xdata(1,1)%xinfo_int  (nlocs, nvar_info))
+  allocate (xdata(1,1)%xinfo_char (nlocs, nvar_info))
+  allocate (xdata(1,1)%xseninfo_float(nlocs, nsen_info))
+  allocate (xdata(1,1)%xseninfo_int  (nvars, nsen_info))
+  allocate (xdata(1,1)%xinfo_int64(nlocs, nvar_info))
+  xdata(1,1)%xinfo_float   (:,:) = missing_r
+  xdata(1,1)%xinfo_int     (:,:) = missing_i
+  xdata(1,1)%xinfo_char    (:,:) = ''
+  xdata(1,1)%xseninfo_float(:,:) = missing_r
+  xdata(1,1)%xseninfo_int  (:,:) = missing_i
+  xdata(1,1)%xinfo_int64   (:,:) = 0
+  if ( nvars > 0 ) then
+     allocate (xdata(1,1)%xfield(nlocs, nvars))
+     xdata(1,1)%xfield(:,:)%val = missing_r
+     xdata(1,1)%xfield(:,:)%qm  = missing_i
+     xdata(1,1)%xfield(:,:)%err = missing_r
+     allocate (xdata(1,1)%var_idx(nvars))
+     do iv = 1, nvars
+        xdata(1,1)%var_idx(iv) = iv
+     end do
+  end if
+
+  iloc = 0
+  y_loop:     do iy=first_boxcenter, nline, superob_width
+  ! start x_loop
+     jbox = iy/superob_width + 1
+     if ( superob_halfwidth .gt. 0 ) then
+        box_bottom = superob_width * (jbox-1) +1
+        box_upper  = superob_width * jbox
+     else
+        box_bottom = superob_width * (jbox-1)
+        box_upper  = superob_width * (jbox-1)
+     end if
+
+     x_loop:      do ix=first_boxcenter, npixel, superob_width
+        if ( .not. valid(ix,iy) ) cycle
+        if ( satzen(ix,iy)  > 65.0 ) cycle x_loop
+        if ( all(brit(ix,iy,:) < 0.0) ) cycle
+
+        ibox = ix/superob_width + 1
+        if ( superob_halfwidth .gt. 0 ) then
+           box_left  = superob_width * (ibox-1) +1 ! will exceed nlatitude/nlongitude if superob_halfwidth = 0
+           box_right = superob_width * ibox
+        else
+           box_left  = superob_width * (ibox-1)
+           box_right = superob_width * (ibox-1)
+        end if
+
+        if ( box_right .gt. npixel ) then
+           box_right = npixel
+        end if
+
+        if ( box_upper .gt. nline ) then
+           box_upper = nline
+        end if
+
+        iloc = iloc + 1
+        ! Super-ob BT for this channel
+        do k = 1, nband
+           nkeep = count(brit(box_left:box_right,box_bottom:box_upper,k) > 0.0 )
+           temp1 = sum  (brit(box_left:box_right,box_bottom:box_upper,k), &
+                         brit(box_left:box_right,box_bottom:box_upper,k) > 0.0 )
+           if (superob_halfwidth .gt.0 .and. nkeep .gt. 0) then
+              tb = temp1 / real(nkeep,8)
+           else
+              ! Extract single pixel BT and radiance value for this channel
+              tb = brit(ix,iy,k)
+           end if
+           bt_sup(ix,iy,k) = tb
+        end do
+  !print*,ix,iy, latitude(ix,iy), longitude(ix,iy), satzen(ix,iy), solzen(ix,iy), bt_sup(ix,iy,2)
+
+        do i = 1, nvar_info
+           if ( type_var_info(i) == nf90_int ) then
+           else if ( type_var_info(i) == nf90_float ) then
+              if ( trim(name_var_info(i)) == 'station_elevation' ) then
+                 xdata(1,1)%xinfo_float(iloc,i) = missing_r
+              else if ( trim(name_var_info(i)) == 'latitude' ) then
+                 xdata(1,1)%xinfo_float(iloc,i) = latitude(ix,iy)
+              else if ( trim(name_var_info(i)) == 'longitude' ) then
+                 xdata(1,1)%xinfo_float(iloc,i) = longitude(ix,iy)
+              end if
+           else if ( type_var_info(i) == nf90_char ) then
+              if ( trim(name_var_info(i)) == 'datetime' ) then
+                 xdata(1,1)%xinfo_char(iloc,i) = datetime
+              else if ( trim(name_var_info(i)) == 'station_id' ) then
+                 xdata(1,1)%xinfo_char(iloc,i) = 'ahi_himawari8'
+              end if
+           else if ( type_var_info(i) == nf90_int64 ) then
+              if ( trim(name_var_info(i)) == 'dateTime' ) then
+                 xdata(1,1)%xinfo_int64(iloc,i) = epochtime
+              end if
+           end if
+        end do
+
+        do i = 1, nsen_info
+           if ( type_sen_info(i) == nf90_float ) then
+              if ( trim(name_sen_info(i)) == 'scan_position' ) then
+                 xdata(1,1)%xseninfo_float(iloc,i) = ix
+              else if ( trim(name_sen_info(i)) == 'sensor_zenith_angle' ) then
+                 xdata(1,1)%xseninfo_float(iloc,i) = satzen(ix,iy)
+              else if ( trim(name_sen_info(i)) == 'solar_zenith_angle' ) then
+                 xdata(1,1)%xseninfo_float(iloc,i) = solzen(ix,iy)
+              else if ( trim(name_sen_info(i)) == 'sensor_azimuth_angle' ) then
+                 xdata(1,1)%xseninfo_float(iloc,i) = missing_r
+              else if ( trim(name_sen_info(i)) == 'solar_azimuth_angle' ) then
+                 xdata(1,1)%xseninfo_float(iloc,i) = missing_r
+              else if ( trim(name_sen_info(i)) == 'sensor_view_angle' ) then
+                 !call calc_sensor_view_angle(trim(rlink%inst), rlink%scanpos, xdata(1,1)%xseninfo_float(iloc,i))
+                 xdata(1,1)%xseninfo_float(iloc,i) = satzen(ix,iy)
+              end if
+  !         else if ( type_sen_info(i) == nf90_int ) then
+  !         else if ( type_sen_info(i) == nf90_char ) then
+           end if
+        end do
+
+        iv = ufo_vars_getindex(name_sen_info, 'sensor_channel')
+        xdata(1,1)%xseninfo_int(:,iv) = (/ 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 /)
+
+        do i = 1, nvars
+           xdata(1,1)%xfield(iloc,i)%val = bt_sup(ix,iy,i)
+           xdata(1,1)%xfield(iloc,i)%err = 1.0
+           !call set_brit_obserr(trim(rlink%inst), i, xdata(1,1)%xfield(iloc,i)%err)
+           xdata(1,1)%xfield(iloc,i)%qm  = 0
+        end do
+     end do x_loop
+  end do y_loop
+
+else
+  nlocs = 0
+  do jj = 1, nline , subsample
+     do ii = 1, npixel , subsample
+        if ( valid(ii,jj) ) then
+           nlocs = nlocs + 1
+        end if
+     end do
+  end do
+
+  !print*,'transfering to xdata'
+
+  allocate(xdata(1,1))
+  nvars = nband
+  xdata(1,1) % nlocs = nlocs
+  xdata(1,1) % nrecs = nlocs
+  xdata(1,1) % nvars = nvars
+  ! allocate and initialize
+  allocate (xdata(1,1)%xinfo_float(nlocs, nvar_info))
+  allocate (xdata(1,1)%xinfo_int  (nlocs, nvar_info))
+  allocate (xdata(1,1)%xinfo_char (nlocs, nvar_info))
+  allocate (xdata(1,1)%xseninfo_float(nlocs, nsen_info))
+  allocate (xdata(1,1)%xseninfo_int  (nvars, nsen_info))
+  allocate (xdata(1,1)%xinfo_int64(nlocs, nvar_info))
+  xdata(1,1)%xinfo_float   (:,:) = missing_r
+  xdata(1,1)%xinfo_int     (:,:) = missing_i
+  xdata(1,1)%xinfo_char    (:,:) = ''
+  xdata(1,1)%xseninfo_float(:,:) = missing_r
+  xdata(1,1)%xseninfo_int  (:,:) = missing_i
+  xdata(1,1)%xinfo_int64   (:,:) = 0
+  if ( nvars > 0 ) then
+     allocate (xdata(1,1)%xfield(nlocs, nvars))
+     xdata(1,1)%xfield(:,:)%val = missing_r
+     xdata(1,1)%xfield(:,:)%qm  = missing_i
+     xdata(1,1)%xfield(:,:)%err = missing_r
+     allocate (xdata(1,1)%var_idx(nvars))
+     do iv = 1, nvars
+        xdata(1,1)%var_idx(iv) = iv
+     end do
+  end if
+
+  ! do thinning every subsample pixels
+  do jj = 1, nline, subsample
+     do ii = 1, npixel, subsample
+        if ( .not. valid(ii,jj) ) cycle
+        iloc = iloc + 1
+  !print*,ii,jj, latitude(ii,jj), longitude(ii,jj), satzen(ii,jj), solzen(ii,jj), brit(ii,jj,1)
+
+        do i = 1, nvar_info
+           if ( type_var_info(i) == nf90_int ) then
+           else if ( type_var_info(i) == nf90_float ) then
+              if ( trim(name_var_info(i)) == 'station_elevation' ) then
+                 xdata(1,1)%xinfo_float(iloc,i) = missing_r
+              else if ( trim(name_var_info(i)) == 'latitude' ) then
+                 xdata(1,1)%xinfo_float(iloc,i) = latitude(ii,jj)
+              else if ( trim(name_var_info(i)) == 'longitude' ) then
+                 xdata(1,1)%xinfo_float(iloc,i) = longitude(ii,jj)
+              end if
+           else if ( type_var_info(i) == nf90_char ) then
+              if ( trim(name_var_info(i)) == 'datetime' ) then
+                 xdata(1,1)%xinfo_char(iloc,i) = datetime
+              else if ( trim(name_var_info(i)) == 'station_id' ) then
+                 xdata(1,1)%xinfo_char(iloc,i) = 'ahi_himawari8'
+              end if
+           else if ( type_var_info(i) == nf90_int64 ) then
+              if ( trim(name_var_info(i)) == 'dateTime' ) then
+                 xdata(1,1)%xinfo_int64(iloc,i) = epochtime
+              end if
+           end if
+        end do
+
+        do i = 1, nsen_info
+           if ( type_sen_info(i) == nf90_float ) then
+              if ( trim(name_sen_info(i)) == 'scan_position' ) then
+                 xdata(1,1)%xseninfo_float(iloc,i) = ii
+              else if ( trim(name_sen_info(i)) == 'sensor_zenith_angle' ) then
+                 xdata(1,1)%xseninfo_float(iloc,i) = satzen(ii,jj)
+              else if ( trim(name_sen_info(i)) == 'solar_zenith_angle' ) then
+                 xdata(1,1)%xseninfo_float(iloc,i) = solzen(ii,jj)
+              else if ( trim(name_sen_info(i)) == 'sensor_azimuth_angle' ) then
+                 xdata(1,1)%xseninfo_float(iloc,i) = missing_r
+              else if ( trim(name_sen_info(i)) == 'solar_azimuth_angle' ) then
+                 xdata(1,1)%xseninfo_float(iloc,i) = missing_r
+              else if ( trim(name_sen_info(i)) == 'sensor_view_angle' ) then
+                 !call calc_sensor_view_angle(trim(rlink%inst), rlink%scanpos, xdata(1,1)%xseninfo_float(iloc,i))
+                 xdata(1,1)%xseninfo_float(iloc,i) = satzen(ii,jj)
+              end if
+  !         else if ( type_sen_info(i) == nf90_int ) then
+  !         else if ( type_sen_info(i) == nf90_char ) then
+           end if
+        end do
+
+        iv = ufo_vars_getindex(name_sen_info, 'sensor_channel')
+        xdata(1,1)%xseninfo_int(:,iv) = (/ 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 /)
+
+        do i = 1, nvars
+           xdata(1,1)%xfield(iloc,i)%val = brit(ii,jj,i)
+           xdata(1,1)%xfield(iloc,i)%err = 1.0
+           !call set_brit_obserr(trim(rlink%inst), i, xdata(1,1)%xfield(iloc,i)%err)
+           xdata(1,1)%xfield(iloc,i)%qm  = 0
+        end do
+     end do
+  end do
+
+end if ! if do_superob
 
 end subroutine read_HSD
 


### PR DESCRIPTION
This PR adds the superobbing capability for AHI observations. Giving the half width of the superobbing grid as an entry parameter, the code computes the average brightness temperature in the box defined using that parameter. This code is adapted from https://github.com/wrf-model/WRF/blob/develop/var/da/da_radiance/da_read_obs_netcdf4ahi_jaxa.inc and follows the same implementation as for ABI observations from GOES-16. The debugging build flags for the goes_abi code are removed. The following figures show the brightness temperature results for AHI observations after using this converter for 2018-04-15T00 channel 8 (a) without superobbing and  (b) with superobbing on a grid of 59x59 pixels:
**a)**
![RAW_2018041500_b8coverage_test_20220721_ch8_08_12](https://user-images.githubusercontent.com/33061897/184459639-fa6a39bb-9d83-4458-8724-3b42922898b5.png)
**b)**
![RAW_2018041500_b8coverage_test_20220721_superobbing59X59](https://user-images.githubusercontent.com/33061897/184459648-9ac5d155-76a5-435c-be7a-aa6e5255743e.png)

**Issue closed**
Closes https://github.com/NCAR/obs2ioda/issues/1