### PR TITLE
Feature/obs2ioda v2 refactor main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-
+*.sh
+*.o
+*.x
+*.mod
 .DS_Store
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,14 @@
 # Check CMake version
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
+enable_language(Fortran)
+set(CMAKE_BUILD_TYPE Debug)
 
 include("${CMAKE_SOURCE_DIR}/cmake/Functions/Obs2Ioda_Functions.cmake")
 # Define the project
 project(obs2ioda LANGUAGES Fortran C CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 # Fortran module output directory for build interface
 set(OBS2IODA_MODULE_DIR ${PROJECT_NAME}/module/${CMAKE_Fortran_COMPILER_ID}/${CMAKE_Fortran_COMPILER_VERSION})
@@ -15,18 +18,14 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/${OBS2IODA_MODULE_DIR}/ DESTINATION ${CMAK
 
 # Set the Fortran compiler and flags
 set(NCEP_BUFR_LIB CACHE STRING "")
-option(BUILD_TESTS "Build unit tests" OFF)
+option(BUILD_TESTS "Build unit tests" ON)
 
 # Find required packages
 find_package(NetCDF REQUIRED COMPONENTS Fortran C)
-
-enable_testing()
-find_package(PFUNIT REQUIRED)
 
 add_subdirectory("${CMAKE_SOURCE_DIR}/obs2ioda-v2")
 if (BUILD_TESTS)
     enable_testing()
     find_package(PFUNIT REQUIRED)
     add_subdirectory("${CMAKE_SOURCE_DIR}/tests")
-endif ()
-
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 
 include("${CMAKE_SOURCE_DIR}/cmake/Functions/Obs2Ioda_Functions.cmake")
 # Define the project
-project(obs2ioda LANGUAGES Fortran)
+project(obs2ioda LANGUAGES Fortran C CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -14,10 +14,19 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/${OBS2IODA_MODULE_DIR}/ DESTINATION ${CMAK
 
 
 # Set the Fortran compiler and flags
-set(NCEP_BUFR_LIB CACHE STRING "" )
+set(NCEP_BUFR_LIB CACHE STRING "")
+option(BUILD_TESTS "Build unit tests" OFF)
 
 # Find required packages
 find_package(NetCDF REQUIRED COMPONENTS Fortran C)
 
+enable_testing()
+find_package(PFUNIT REQUIRED)
+
 add_subdirectory("${CMAKE_SOURCE_DIR}/obs2ioda-v2")
+if (BUILD_TESTS)
+    enable_testing()
+    find_package(PFUNIT REQUIRED)
+    add_subdirectory("${CMAKE_SOURCE_DIR}/tests")
+endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,12 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/${OBS2IODA_MODULE_DIR}/ DESTINATION ${CMAK
 
 
 # Set the Fortran compiler and flags
-set(NCEP_BUFR_LIB CACHE STRING "")
+set(NCEP_BUFR_ROOT CACHE STRING "")
 option(BUILD_TESTS "Build unit tests" ON)
 
 # Find required packages
 find_package(NetCDF REQUIRED COMPONENTS Fortran C)
+find_package(NCEPBUFR REQUIRED)
 
 add_subdirectory("${CMAKE_SOURCE_DIR}/obs2ioda-v2")
 if (BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Check CMake version
 cmake_minimum_required(VERSION 3.20)
 enable_language(Fortran)
-set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_BUILD_TYPE Release)
 
 include("${CMAKE_SOURCE_DIR}/cmake/Functions/Obs2Ioda_Functions.cmake")
 # Define the project

--- a/cmake/Modules/FindNCEPBUFR.cmake
+++ b/cmake/Modules/FindNCEPBUFR.cmake
@@ -1,0 +1,34 @@
+# FindNCEPBUFR.cmake
+# This script finds the first occurrence of a library matching "*libbufr*" with extensions
+# .a, .so, or .dylib in NCEPBUFR_ROOT and creates an imported target.
+
+# Ensure NCEPBUFR_ROOT is defined
+if(NOT DEFINED NCEPBUFR_ROOT)
+    message(WARNING "NCEPBUFR_ROOT is not defined. Please set it to the root directory of the NCEP BUFR installation.")
+    set(NCEPBUFR_FOUND FALSE)
+    return()
+endif()
+
+# Recursive search for any file containing "libbufr" in its name and ending with .a, .so, or .dylib
+file(GLOB_RECURSE NCEPBUFR_LIB_FILES
+     "${NCEPBUFR_ROOT}/*libbufr*.a"
+     "${NCEPBUFR_ROOT}/*libbufr*.so"
+     "${NCEPBUFR_ROOT}/*libbufr*.dylib"
+)
+
+# Check if any matching file was found
+if(NCEPBUFR_LIB_FILES)
+    list(GET NCEPBUFR_LIB_FILES 0 NCEPBUFR_LIB_FILE)  # Take the first match
+    set(NCEPBUFR_FOUND TRUE)
+    message(STATUS "Found libbufr library: ${NCEPBUFR_LIB_FILE}")
+
+    # Create an imported target for the found library
+    add_library(NCEPBUFR::libbufr UNKNOWN IMPORTED)
+    set_target_properties(NCEPBUFR::libbufr PROPERTIES
+                          IMPORTED_LOCATION "${NCEPBUFR_LIB_FILE}"
+    )
+
+else()
+    set(NCEPBUFR_FOUND FALSE)
+    message(WARNING "Could not find libbufr library in ${NCEPBUFR_ROOT}")
+endif()

--- a/obs2ioda-v2/CMakeLists.txt
+++ b/obs2ioda-v2/CMakeLists.txt
@@ -24,7 +24,7 @@ set(v2_MAIN_SOURCE
     main.f90
 )
 list(TRANSFORM v2_MAIN_SOURCE PREPEND "src/")
-set(v2_PUBLIC_LINK_LIBRARIES "${NetCDF_LIBRARIES}" "${NCEP_BUFR_LIB}")
+set(v2_PUBLIC_LINK_LIBRARIES "${NetCDF_LIBRARIES}" NCEPBUFR::libbufr)
 add_library(v2 SHARED ${v2_SOURCES})
 obs2ioda_fortran_target(v2 ${v2_MAIN_SOURCE})
 

--- a/obs2ioda-v2/CMakeLists.txt
+++ b/obs2ioda-v2/CMakeLists.txt
@@ -13,6 +13,8 @@ set(v2_SOURCES
     ncio_mod.f90
     netcdf_mod.f90
     prepbufr_mod.f90
+    core_mod.f90
+    setup_mod.f90
     radiance_mod.f90
     ufo_variables_mod.F90
     utils_mod.f90

--- a/obs2ioda-v2/README.md
+++ b/obs2ioda-v2/README.md
@@ -18,13 +18,13 @@ If you have an environment preconfigured for `mpas-jedi`, simply source that env
    ```bash
    mkdir build && cd build
    ```
-3. Locate the NCEP BUFR library by executing the following command in the `NCEP BUFR` library's build directory:
+3. Set the environment variable `NCEPBUFR_ROOT` to the root directory where the NCEP BUFR library is installed.
    ```bash
-   find . -name *libbufr*
+    export NCEPBUFR_ROOT=<NCEP_BUFR_ROOT_DIR>
    ```
 4. Next, run CMake to configure the build. Remember to specify the path to the NCEP BUFR library:
    ```bash
-   cmake <OBS2IODA_ROOT_DIR> -DNCEP_BUFR_LIB=<NCEP_BUFR_LIB_PATH>
+   cmake <OBS2IODA_ROOT_DIR> -DNCEPBUFR_ROOT=<NCEPBUFR_ROOT>
    ```
 5. Finally, build the project using this command:
    ```bash

--- a/obs2ioda-v2/src/Makefile
+++ b/obs2ioda-v2/src/Makefile
@@ -1,24 +1,28 @@
 #! /bin/sh -v
 
-#------------
-#GNU compiler
-#------------
-#FC = gfortran
-#BUFR_LIB = -L/glade/u/home/hclin/extlib -lbufr
-#GNU10 = #-fallow-argument-mismatch -fallow-invalid-boz
-#FFLAGS = -ffree-line-length-none ${GNU10} #-fbacktrace -ggdb -fcheck=bounds,do,mem,pointer -ffpe-trap=invalid,zero,overflow
+FC = gfortran
+BUFR_LIB = -L${BUFR_LIB_DIR} -l${BUFR_LIB_NAME}
+NC_LIB = $(shell nc-config --libs)
+NC_INC = $(shell nc-config --includedir)
+NF_LIB = $(shell nf-config --flibs)
+NF_INC = $(shell nf-config --includedir)
+LIBS = ${BUFR_LIB} ${NC_LIB} ${NF_LIB}
+INCS = -I${NC_INC} -I${NF_INC}
+FC = gfortran
+FFLAGS = -mcmodel=medium -ffree-line-length-none
+
 
 #--------------
 #INTEL compiler
 #--------------
-FC = ifort
+#FC = ifort
 #BUFR_LIB = -L/glade/u/home/hclin/extlib/intel -lbufr
 #FFLAGS = -mcmodel medium # needed for intel error message "failed to convert GOTPCREL relocation"
-BUFR_LIB = -L/glade/campaign/mmm/parc/ivette/pandac/converters/WRFDA_3DVAR_dmpar/var/external/bufr -lbufr
-FFLAGS = -mcmodel medium # needed for intel error message "failed to convert GOTPCREL relocation" # -g -traceback -debug all -check all
+#BUFR_LIB = -L/glade/campaign/mmm/parc/ivette/pandac/converters/WRFDA_3DVAR_dmpar/var/external/bufr -lbufr
+#FFLAGS = -mcmodel medium # needed for intel error message "failed to convert GOTPCREL relocation" # -g -traceback -debug all -check all
 
-LIBS = -L$(NETCDF)/lib -lnetcdff -lnetcdf ${BUFR_LIB}
-INCS = -I$(NETCDF)/include
+#LIBS = -L$(NETCDF)/lib -lnetcdff -lnetcdf ${BUFR_LIB}
+#INCS = -I$(NETCDF)/include
 
 OBJS = \
        define_mod.o \
@@ -32,7 +36,8 @@ OBJS = \
        prepbufr_mod.o \
        radiance_mod.o \
        ufo_variables_mod.o \
-       utils_mod.o
+       utils_mod.o \
+       setup_mod.o
 
 all: obs2ioda
 
@@ -41,14 +46,16 @@ obs2ioda: ${OBJS}
 
 kinds.o : kinds.f90
 define_mod.o : define_mod.f90 kinds.o ufo_variables_mod.o
-gnssro_mod.o : gnssro_mod.f90
-hsd.o : hsd.f90 kinds.o define_mod.o ufo_variables_mod.o ncio_mod.o utils_mod.o
-main.o : main.f90 define_mod.f90 prepbufr_mod.o ncio_mod.o radiance_mod.o gnssro_mod.o hsd.o satwnd_mod.o
-ncio_mod.o : ncio_mod.f90 kinds.o prepbufr_mod.o netcdf_mod.o ufo_variables_mod.o define_mod.o
+setup_mod.o : setup_mod.f90 kinds.o define_mod.o
+core_mod.o : core_mod.f90 kinds.o define_mod.o
+gnssro_mod.o : gnssro_mod.f90 core_mod.o
+hsd.o : hsd.f90 kinds.o define_mod.o ufo_variables_mod.o ncio_mod.o utils_mod.o core_mod.o
+main.o : main.f90 define_mod.f90 prepbufr_mod.o ncio_mod.o radiance_mod.o gnssro_mod.o hsd.o satwnd_mod.o setup_mod.o core_mod.o
+ncio_mod.o : ncio_mod.f90 kinds.o netcdf_mod.o ufo_variables_mod.o define_mod.o
 netcdf_mod.o : netcdf_mod.f90
-prepbufr_mod.o : prepbufr_mod.f90 kinds.o ufo_variables_mod.o utils_mod.o define_mod.o
-radiance_mod.o : radiance_mod.f90 kinds.o define_mod.o ufo_variables_mod.o utils_mod.o
-satwnd_mod.o : satwnd_mod.f90 kinds.o define_mod.o ufo_variables_mod.o
+prepbufr_mod.o : prepbufr_mod.f90 kinds.o ufo_variables_mod.o utils_mod.o define_mod.o core_mod.o ncio_mod.o
+radiance_mod.o : radiance_mod.f90 kinds.o define_mod.o ufo_variables_mod.o utils_mod.o core_mod.o ncio_mod.o
+satwnd_mod.o : satwnd_mod.f90 kinds.o define_mod.o ufo_variables_mod.o core_mod.o ncio_mod.o
 ufo_variables_mod.o : ufo_variables_mod.F90
 utils_mod.o : utils_mod.f90
 

--- a/obs2ioda-v2/src/core_mod.f90
+++ b/obs2ioda-v2/src/core_mod.f90
@@ -1,0 +1,59 @@
+module core_mod
+    use define_mod, only: write_nc_radiance, xdata_type, write_nc_conv, &
+        write_nc_radiance_geo
+    use kinds, only: i_kind
+    private
+    integer(i_kind), parameter :: NameLen_   = 64
+    integer(i_kind), parameter :: DateLen_   = 10
+    integer(i_kind), parameter :: DateLen14_ = 14
+    integer(i_kind), parameter :: nfile_all_ = 8
+    public :: obs2ioda_args_t
+    type obs2ioda_args_t
+        character(len=NameLen_) :: filename
+        character(len=DateLen_) :: filedate
+        character(len=DateLen_) :: filedate_out
+        integer(i_kind) :: nfgat
+        integer(i_kind) :: hour_fgat
+        type(xdata_type), allocatable, dimension(:,:) :: xdata  ! dim 1: number of ob types
+        logical :: do_radiance = .false.
+        logical :: do_radiance_hyperIR = .false.
+        logical :: apply_gsi_qc = .true.
+        logical :: do_tv_to_ts = .true.
+        logical :: do_ahi = .false.
+        logical :: time_split = .false.
+        logical :: do_superob = .false.
+        character(len=:), allocatable :: inpdir
+        character(len=:), allocatable :: outdir
+        character(len=:), allocatable :: cdatetime
+        integer(i_kind) :: subsample
+        integer(i_kind) :: superob_halfwidth
+        integer(i_kind) :: NameLen   = NameLen_
+        integer(i_kind) :: DateLen   = DateLen_
+        integer(i_kind) :: DateLen14 = DateLen14_
+        integer(i_kind) :: nfile_all = nfile_all_
+        integer(i_kind) :: ftype_unknown  = -1
+        integer(i_kind) :: ftype_prepbufr =  1
+        integer(i_kind) :: ftype_gnssro   =  2
+        integer(i_kind) :: ftype_amsua    =  3
+        integer(i_kind) :: ftype_mhs      =  4
+        integer(i_kind) :: ftype_airs     =  5
+        integer(i_kind) :: ftype_satwnd   =  6
+        integer(i_kind) :: ftype_iasi     =  7
+        integer(i_kind) :: ftype_cris     =  8
+        integer(i_kind) :: write_nc_radiance_geo = write_nc_radiance_geo
+        integer(i_kind) :: write_nc_radiance     = write_nc_radiance
+        integer(i_kind) :: write_nc_conv         = write_nc_conv
+        character(len=NameLen_) :: flist
+        character(len=NameLen_)     :: flist_all(nfile_all_) = &
+                (/                    &
+                        "gnssro.bufr    ", &
+                                "prepbufr.bufr  ", &
+                                "satwnd.bufr    ", &
+                                "amsua.bufr     ", &
+                                "airs.bufr      ", &
+                                "mhs.bufr       ", &
+                                "iasi.bufr      ", &
+                                "cris.bufr      "  &
+                        /)
+end type obs2ioda_args_t
+end module core_mod

--- a/obs2ioda-v2/src/define_mod.f90
+++ b/obs2ioda-v2/src/define_mod.f90
@@ -230,8 +230,6 @@ type xdata_type
    real(r_kind),           allocatable, dimension(:)   :: wavenumber
 end type xdata_type
 
-type(xdata_type), allocatable, dimension(:,:) :: xdata  ! dim 1: number of ob types
-                                                        ! dim 2: number of time slots
 
 contains
 

--- a/obs2ioda-v2/src/get_signature.sh
+++ b/obs2ioda-v2/src/get_signature.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# check arguments
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <directory> <function_name>"
+    exit 1
+fi
+
+directory=$1
+function_name=$2
+
+find "$directory" -name "*.f" -o -name "*.f90" | while read file; do
+    grep -ne "subroutine ${function_name}(\|function ${function_name}(" "$file" && echo -e "\tFound in $file"
+done

--- a/obs2ioda-v2/src/gnssro_mod.f90
+++ b/obs2ioda-v2/src/gnssro_mod.f90
@@ -7,6 +7,7 @@
 
 module gnssro_bufr2ioda
 use netcdf
+use core_mod, only: obs2ioda_args_t
 implicit none
 
 integer, parameter :: i_kind  = selected_int_kind(8)    !4
@@ -17,6 +18,12 @@ integer(i_kind) :: said
 logical :: verbose = .false.
 
 contains
+
+subroutine handle_gnssro(obs2ioda_args)
+    implicit none
+    type(obs2ioda_args_t), intent(inout) :: obs2ioda_args
+    call read_write_gnssro(trim(obs2ioda_args%inpdir)//trim(obs2ioda_args%filename), trim(obs2ioda_args%outdir))
+end subroutine handle_gnssro
 
 subroutine read_write_gnssro(infile, outdir)
 

--- a/obs2ioda-v2/src/main.f90
+++ b/obs2ioda-v2/src/main.f90
@@ -1,7 +1,7 @@
 program obs2ioda
 
 use define_mod, only: write_nc_conv, write_nc_radiance, &
-        write_nc_radiance_geo, xdata_type
+        write_nc_radiance_geo, xdata_type, StrLen
 use kinds, only: i_kind
 use prepbufr_mod, only: handle_prepbufr
 use radiance_mod, only: handle_amsua, handle_airs, &
@@ -14,7 +14,7 @@ use satwnd_mod, only: handle_satwnd
 use utils_mod, only: da_advance_time
 use setup_mod, only: &
         parse_files_to_convert, handle_user_input,&
-        set_nfgat, input_file_exists
+        set_nfgat, input_file_exists, set_command_line_arguments
 use core_mod, only: obs2ioda_args_t
 
 implicit none
@@ -24,12 +24,18 @@ type(obs2ioda_args_t), target :: obs2ioda_args
 character(len=1024) :: arg, cmd_line  ! adjust char len as per maximum expected cmd line length
 integer :: i, num
 integer, dimension(:), allocatable :: cmd_arg_indicies
+character(len=StrLen), dimension(:), allocatable :: command_line_args
 
 character (len=64) :: flist(8)  ! file names to be read in from command line arguments
-integer(i_kind)         :: nfile, ifile
+integer(i_kind)         :: nfile, ifile, arg_count
 
+arg_count = command_argument_count()
+allocate(command_line_args(arg_count))
 
-call handle_user_input(obs2ioda_args,flist, ftype, nfile)
+call set_command_line_arguments(command_line_args)
+
+call handle_user_input(obs2ioda_args,flist, ftype, nfile, command_line_args)
+stop
 call parse_files_to_convert(obs2ioda_args, flist, ftype, nfile)
 
 call set_nfgat(obs2ioda_args)

--- a/obs2ioda-v2/src/main.f90
+++ b/obs2ioda-v2/src/main.f90
@@ -35,7 +35,6 @@ allocate(command_line_args(arg_count))
 call set_command_line_arguments(command_line_args)
 
 call handle_user_input(obs2ioda_args,flist, ftype, nfile, command_line_args)
-stop
 call parse_files_to_convert(obs2ioda_args, flist, ftype, nfile)
 
 call set_nfgat(obs2ioda_args)

--- a/obs2ioda-v2/src/main.f90
+++ b/obs2ioda-v2/src/main.f90
@@ -1,413 +1,118 @@
 program obs2ioda
 
-use define_mod, only: write_nc_conv, write_nc_radiance, write_nc_radiance_geo, StrLen, xdata, &
-   ninst
+use define_mod, only: write_nc_conv, write_nc_radiance, &
+        write_nc_radiance_geo, xdata_type
 use kinds, only: i_kind
-use prepbufr_mod, only: read_prepbufr, sort_obs_conv, filter_obs_conv, do_tv_to_ts
-use radiance_mod, only: read_amsua_amsub_mhs, read_airs_colocate_amsua, sort_obs_radiance, &
-   read_iasi, read_cris, radiance_to_temperature
-use ncio_mod, only: write_obs
-use gnssro_bufr2ioda, only: read_write_gnssro
-use ahi_hsd_mod, only: read_hsd, subsample
-use satwnd_mod, only: read_satwnd, filter_obs_satwnd, sort_obs_satwnd
+use prepbufr_mod, only: handle_prepbufr
+use radiance_mod, only: handle_amsua, handle_airs, &
+        handle_mhs, handle_do_radiance, &
+        handle_do_radiance_hyper_ir, handle_iasi, &
+        handle_cris
+use gnssro_bufr2ioda, only: handle_gnssro
+use ahi_hsd_mod, only: handle_do_ahi
+use satwnd_mod, only: handle_satwnd
 use utils_mod, only: da_advance_time
+use setup_mod, only: &
+        parse_files_to_convert, handle_user_input,&
+        set_nfgat, input_file_exists
+use core_mod, only: obs2ioda_args_t
 
 implicit none
 
-integer(i_kind), parameter :: NameLen   = 64
-integer(i_kind), parameter :: DateLen   = 10
-integer(i_kind), parameter :: DateLen14 = 14
-integer(i_kind), parameter :: nfile_all = 8
-integer(i_kind), parameter :: ftype_unknown  = -1
-integer(i_kind), parameter :: ftype_prepbufr =  1
-integer(i_kind), parameter :: ftype_gnssro   =  2
-integer(i_kind), parameter :: ftype_amsua    =  3
-integer(i_kind), parameter :: ftype_mhs      =  4
-integer(i_kind), parameter :: ftype_airs     =  5
-integer(i_kind), parameter :: ftype_satwnd   =  6
-integer(i_kind), parameter :: ftype_iasi     =  7
-integer(i_kind), parameter :: ftype_cris     =  8
+integer(i_kind)            :: ftype(8)
+type(obs2ioda_args_t), target :: obs2ioda_args
+character(len=1024) :: arg, cmd_line  ! adjust char len as per maximum expected cmd line length
+integer :: i, num
+integer, dimension(:), allocatable :: cmd_arg_indicies
 
-integer(i_kind)            :: ftype(nfile_all)
-character(len=NameLen)     :: flist_all(nfile_all) = &
-   (/                    &
-      "gnssro.bufr    ", &
-      "prepbufr.bufr  ", &
-      "satwnd.bufr    ", &
-      "amsua.bufr     ", &
-      "airs.bufr      ", &
-      "mhs.bufr       ", &
-      "iasi.bufr      ", &
-      "cris.bufr      "  &
-   /)
-character (len=NameLen) :: flist(nfile_all)  ! file names to be read in from command line arguments
-character (len=NameLen) :: filename
-character (len=DateLen) :: filedate, filedate_out
-character (len=StrLen)  :: inpdir, outdir, cdatetime
-logical                 :: fexist
-logical                 :: do_radiance
-logical                 :: do_radiance_hyperIR
-logical                 :: do_ahi, do_superob
-logical                 :: apply_gsi_qc
-logical                 :: time_split
-integer(i_kind)         :: nfgat, hour_fgat
+character (len=64) :: flist(8)  ! file names to be read in from command line arguments
 integer(i_kind)         :: nfile, ifile
-integer(i_kind)         :: itmp
-integer(i_kind)         :: itime
-integer(i_kind)         :: superob_halfwidth
-character (len=DateLen14) :: dtime, datetmp
 
 
-do_tv_to_ts = .true.
-do_radiance = .false. ! initialize
-do_radiance_hyperIR = .false. ! initialize
-do_ahi = .false.
-do_superob = .false.
-apply_gsi_qc = .true. !.false.
-time_split = .false.
+call handle_user_input(obs2ioda_args,flist, ftype, nfile)
+call parse_files_to_convert(obs2ioda_args, flist, ftype, nfile)
 
-call parse_files_to_convert
-
-if ( time_split ) then
-   hour_fgat = 1  ! can also be 3 or 2
-   ! corresponding to dtime_min='-3h' and dtime_max='+3h'
-   nfgat = (6/hour_fgat) + 1
-else
-   nfgat = 1
-end if
+call set_nfgat(obs2ioda_args)
 
 do ifile = 1, nfile
 
-   filename = flist(ifile)
+   obs2ioda_args%filename = flist(ifile)
 
-   if ( ftype(ifile) == ftype_gnssro ) then
-      inquire(file=trim(inpdir)//trim(filename), exist=fexist)
-      if ( .not. fexist ) then
-         write(*,*) 'Warning: ', trim(inpdir)//trim(filename), ' not found for decoding...'
-      else
-         write(*,*) '--- processing gnssro.bufr ---'
-         call read_write_gnssro(trim(inpdir)//trim(filename), trim(outdir))
+   if ( ftype(ifile) == obs2ioda_args%ftype_gnssro ) then
+      if ( input_file_exists(obs2ioda_args) ) then
+         call handle_gnssro(obs2ioda_args)
       end if
    end if
 
-   if ( ftype(ifile) == ftype_satwnd ) then
-      inquire(file=trim(inpdir)//trim(filename), exist=fexist)
-      if ( .not. fexist ) then
-         write(*,*) 'Warning: ', trim(inpdir)//trim(filename), ' not found for decoding...'
-      else
-         ! read satwnd file and store data in sequential linked list for conv obs
-         call read_satwnd(trim(inpdir)//trim(filename), filedate)
-
-         if ( apply_gsi_qc ) then
-            write(*,*) '--- applying some additional QC as in GSI read_satwnd.f90 for the global model ---'
-            call filter_obs_satwnd
-         end if
-
-         ! transfer info from limked list to arrays grouped by obs/variable types
-         call sort_obs_satwnd(filedate, nfgat)
-
-         ! write out netcdf files
-         if ( nfgat > 1 ) then
-            do itime = 1, nfgat
-               ! corresponding to dtime_min='-3h' and dtime_max='+3h'
-               write(dtime,'(i2,a)')  hour_fgat*(itime-1)-3, 'h'
-               call da_advance_time(filedate, trim(dtime), datetmp)
-               filedate_out = datetmp(1:10)
-               call write_obs(filedate_out, write_nc_conv, outdir, itime)
-            end do
-         else
-            call write_obs(filedate, write_nc_conv, outdir, 1)
-         end if
-         if ( allocated(xdata) ) deallocate(xdata)
+   if ( ftype(ifile) == obs2ioda_args%ftype_satwnd ) then
+      if ( input_file_exists(obs2ioda_args) ) then
+         call  handle_satwnd( &
+                 obs2ioda_args &
+                 )
       end if
    end if
 
-   if ( ftype(ifile) == ftype_prepbufr ) then
-      inquire(file=trim(inpdir)//trim(filename), exist=fexist)
-      if ( .not. fexist ) then
-         write(*,*) 'Warning: ', trim(inpdir)//trim(filename), ' not found for decoding...'
-      else
-         ! read prepbufr file and store data in sequential linked list for conv obs
-         call read_prepbufr(trim(inpdir)//trim(filename), filedate)
-
-         if ( apply_gsi_qc ) then
-            write(*,*) '--- applying some additional QC as in GSI read_prepbufr.f90 for the global model ---'
-            call filter_obs_conv
-         end if
-
-         ! transfer info from limked list to arrays grouped by obs/variable types
-         call sort_obs_conv(filedate, nfgat)
-
-         ! write out netcdf files
-         if ( nfgat > 1 ) then
-            do itime = 1, nfgat
-               ! corresponding to dtime_min='-3h' and dtime_max='+3h'
-               write(dtime,'(i2,a)')  hour_fgat*(itime-1)-3, 'h'
-               call da_advance_time(filedate, trim(dtime), datetmp)
-               filedate_out = datetmp(1:10)
-               call write_obs(filedate_out, write_nc_conv, outdir, itime)
-            end do
-         else
-            call write_obs(filedate, write_nc_conv, outdir, 1)
-         end if
-         if ( allocated(xdata) ) deallocate(xdata)
+   if ( ftype(ifile) == obs2ioda_args%ftype_prepbufr ) then
+      if ( input_file_exists(obs2ioda_args) ) then
+         call  handle_prepbufr( &
+                 obs2ioda_args &
+                 )
       end if
    end if
 
-   if ( ftype(ifile) == ftype_amsua ) then
-      inquire(file=trim(inpdir)//trim(filename), exist=fexist)
-      if ( .not. fexist ) then
-         write(*,*) 'Warning: ', trim(inpdir)//trim(filename), ' not found for decoding...'
-      else
-         do_radiance = .true.
-         ! read bufr file and store data in sequential linked list for radiances
-         call read_amsua_amsub_mhs(trim(inpdir)//trim(filename), filedate)
+   if ( ftype(ifile) == obs2ioda_args%ftype_amsua ) then
+      if ( input_file_exists(obs2ioda_args) ) then
+         call handle_amsua(obs2ioda_args)
       end if
    end if
 
-   if ( ftype(ifile) == ftype_airs ) then
-      inquire(file=trim(inpdir)//trim(filename), exist=fexist)
-      if ( .not. fexist ) then
-         write(*,*) 'Warning: ', trim(inpdir)//trim(filename), ' not found for decoding...'
-      else
-         do_radiance = .true.
-         ! read bufr file and store data in sequential linked list for radiances
-         call read_airs_colocate_amsua(trim(inpdir)//trim(filename), filedate)
+   if ( ftype(ifile) == obs2ioda_args%ftype_airs ) then
+      if ( input_file_exists(obs2ioda_args) ) then
+         call handle_airs(obs2ioda_args)
       end if
    end if
 
-   if ( ftype(ifile) == ftype_mhs ) then
-      inquire(file=trim(inpdir)//trim(filename), exist=fexist)
-      if ( .not. fexist ) then
-         write(*,*) 'Warning: ', trim(inpdir)//trim(filename), ' not found for decoding...'
-      else
-         do_radiance = .true.
-         ! read bufr file and store data in sequential linked list for radiances
-         call read_amsua_amsub_mhs(trim(inpdir)//trim(filename), filedate)
+   if ( ftype(ifile) == obs2ioda_args%ftype_mhs ) then
+      if ( input_file_exists(obs2ioda_args) ) then
+         call handle_mhs(obs2ioda_args)
       end if
    end if
 
 end do ! nfile list
 
-if ( do_radiance ) then
-   ! transfer info linked list to arrays grouped by satellite instrument types
-   call sort_obs_radiance(filedate, nfgat)
-
-   ! write out netcdf files
-   if ( nfgat > 1 ) then
-      do itime = 1, nfgat
-         ! corresponding to dtime_min='-3h' and dtime_max='+3h'
-         write(dtime,'(i2,a)')  hour_fgat*(itime-1)-3, 'h'
-         call da_advance_time(filedate, trim(dtime), datetmp)
-         filedate_out = datetmp(1:10)
-         call write_obs(filedate_out, write_nc_radiance, outdir, itime)
-      end do
-   else
-      call write_obs(filedate, write_nc_radiance, outdir, 1)
-   end if
-   if ( allocated(xdata) ) deallocate(xdata)
+if ( obs2ioda_args%do_radiance ) then
+   call  handle_do_radiance( &
+              obs2ioda_args &
+           )
 end if
 
 do ifile = 1, nfile
 
-   filename = flist(ifile)
+   obs2ioda_args%filename = flist(ifile)
 
-   if ( ftype(ifile) == ftype_iasi ) then
-      inquire(file=trim(inpdir)//trim(filename), exist=fexist)
-      if ( .not. fexist ) then
-         write(*,*) 'Warning: ', trim(inpdir)//trim(filename), ' not found for decoding...'
-      else
-         do_radiance_hyperIR = .true.
-         ! read bufr file and store data in sequential linked list for radiances
-         call read_iasi(trim(inpdir)//trim(filename), filedate)
+   if ( ftype(ifile) == obs2ioda_args%ftype_iasi ) then
+      if ( input_file_exists(obs2ioda_args) ) then
+         call handle_iasi(obs2ioda_args)
       end if
    end if
 
-   if ( ftype(ifile) == ftype_cris ) then
-      inquire(file=trim(inpdir)//trim(filename), exist=fexist)
-      if ( .not. fexist ) then
-         write(*,*) 'Warning: ', trim(inpdir)//trim(filename), ' not found for decoding...'
-      else
-         do_radiance_hyperIR = .true.
-         ! read bufr file and store data in sequential linked list for radiances
-         call read_cris(trim(inpdir)//trim(filename), filedate)
+   if ( ftype(ifile) == obs2ioda_args%ftype_cris ) then
+      if ( input_file_exists(obs2ioda_args) ) then
+         call handle_cris(obs2ioda_args)
       end if
    end if
-
 end do
 
-if ( do_radiance_hyperIR ) then
-   ! transfer info from linked list to arrays grouped by satellite instrument types
-   call sort_obs_radiance(filedate, nfgat)
-
-   call radiance_to_temperature(ninst, nfgat)
-
-   ! write out netcdf files
-   if ( nfgat > 1 ) then
-      do itime = 1, nfgat
-         ! corresponding to dtime_min='-3h' and dtime_max='+3h'
-         write(dtime,'(i2,a)')  hour_fgat*(itime-1)-3, 'h'
-         call da_advance_time(filedate, trim(dtime), datetmp)
-         filedate_out = datetmp(1:10)
-         call write_obs(filedate_out, write_nc_radiance, outdir, itime)
-      end do
-   else
-      call write_obs(filedate, write_nc_radiance, outdir, 1)
-   end if
-   if ( allocated(xdata) ) deallocate(xdata)
+if ( obs2ioda_args%do_radiance_hyperIR ) then
+   call  handle_do_radiance_hyper_ir( &
+           obs2ioda_args &
+           )
 end if
 
-if ( do_ahi ) then
-   if ( len_trim(cdatetime) /= 12 ) then
-      write(*,*) 'Error: -t ccyymmddhhnn not specified for -ahi'
-      stop
-   end if
-   call read_HSD(cdatetime, inpdir, do_superob, superob_halfwidth)
-   filedate = cdatetime(1:10)
-   call write_obs(filedate, write_nc_radiance_geo, outdir, 1)
-   if ( allocated(xdata) ) deallocate(xdata)
+if ( obs2ioda_args%do_ahi ) then
+   call handle_do_ahi(obs2ioda_args)
 end if
 
 write(6,*) 'all done!'
-
-contains
-
-subroutine parse_files_to_convert
-
-implicit none
-
-integer(i_kind)       :: iunit = 21
-integer(i_kind)       :: narg, iarg, iarg_inpdir, iarg_outdir, iarg_datetime, iarg_subsample, iarg_superob_halfwidth
-integer(i_kind)       :: itmp
-integer(i_kind)       :: iost, iret, idate
-character(len=StrLen) :: strtmp
-character(len=8)      :: subset
-
-narg = command_argument_count()
-ifile = 0
-inpdir = '.'
-outdir = '.'
-cdatetime = ''
-flist(:) = 'null'
-iarg_inpdir = -1
-iarg_outdir = -1
-iarg_datetime = -1
-iarg_subsample = -1
-iarg_superob_halfwidth = -1
-if ( narg > 0 ) then
-   do iarg = 1, narg
-      call get_command_argument(number=iarg, value=strtmp)
-      if ( trim(strtmp) == '-qc' ) then
-         apply_gsi_qc = .true.
-      else if ( trim(strtmp) == '-noqc' ) then
-         apply_gsi_qc = .false.
-      else if ( trim(strtmp) == '-tv' ) then
-         do_tv_to_ts = .false.
-      else if ( trim(strtmp) == '-ahi' ) then
-         do_ahi = .true.
-      else if ( trim(strtmp) == '-split' ) then
-         time_split = .true.
-      else if ( trim(strtmp) == '-i' ) then
-         iarg_inpdir = iarg + 1
-      else if ( trim(strtmp) == '-o' ) then
-         iarg_outdir = iarg + 1
-      else if ( trim(strtmp) == '-t' ) then
-         iarg_datetime = iarg + 1
-      else if ( trim(strtmp) == '-s' ) then
-         iarg_subsample = iarg + 1
-      else if ( trim(strtmp) == '-superob' ) then
-         do_superob = .true.
-         iarg_superob_halfwidth = iarg + 1
-      else
-         if ( iarg == iarg_inpdir ) then
-            call get_command_argument(number=iarg, value=inpdir)
-         else if ( iarg == iarg_outdir ) then
-            call get_command_argument(number=iarg, value=outdir)
-         else if ( iarg == iarg_datetime ) then
-            call get_command_argument(number=iarg, value=cdatetime)
-         else if ( iarg == iarg_subsample ) then
-            call get_command_argument(number=iarg, value=strtmp)
-            if ( len_trim(strtmp) > 0 ) then
-              read(strtmp,'(i2)') subsample
-            else
-              subsample = 1
-            end if
-         else if ( iarg == iarg_superob_halfwidth ) then
-            call get_command_argument(number=iarg, value=strtmp)
-            if ( len_trim(strtmp) > 0 ) then
-              read(strtmp,'(i2)') superob_halfwidth
-            else
-              iarg_superob_halfwidth = 1
-            end if
-         else
-            ifile = ifile + 1
-            call get_command_argument(number=iarg, value=flist(ifile))
-         end if
-      end if
-   end do
-   if ( ifile == 0 ) then
-      nfile = nfile_all
-      flist(:) = flist_all(:)
-      ftype(:) = (/ ftype_gnssro, ftype_prepbufr, ftype_satwnd,  &
-                    ftype_amsua, ftype_airs, ftype_mhs,  &
-                    ftype_iasi, ftype_cris /)
-   else
-      nfile = ifile
-   end if
-else
-   inpdir = '.'
-   outdir = '.'
-   nfile = nfile_all
-   flist(:) = flist_all(:)
-   ftype(:) = (/ ftype_gnssro, ftype_prepbufr, ftype_satwnd,  &
-                 ftype_amsua, ftype_airs, ftype_mhs,  &
-                 ftype_iasi, ftype_cris /)
-end if
-
-itmp = len_trim(inpdir)
-if ( inpdir(itmp:itmp) /= '/' ) inpdir = trim(inpdir)//'/'
-itmp = len_trim(outdir)
-if ( outdir(itmp:itmp) /= '/' ) outdir = trim(outdir)//'/'
-
-! use default file lists if not set in command-line arguemnt
-if ( narg == 0 .or. ifile == 0 ) return
-
-! determine the input file type
-fileloop: do ifile = 1, nfile
-   if ( trim(flist(ifile)) == 'null' ) then
-      ftype(ifile) = ftype_unknown
-      cycle fileloop
-   end if
-   open(unit=iunit, file=trim(inpdir)//trim(flist(ifile)), form='unformatted', iostat=iost, status='old')
-   call openbf(iunit, 'IN', iunit)
-   call readmg(iunit,subset,idate,iret)
-!print*,subset
-   if ( subset(1:5) == 'NC005' ) then
-      ftype(ifile) = ftype_satwnd
-   else
-   select case ( trim(subset) )
-   case (  'ADPUPA', 'ADPSFC' )
-      ftype(ifile) = ftype_prepbufr
-   case ( 'NC003010' )
-      ftype(ifile) = ftype_gnssro
-   case ( 'NC021023' )
-      ftype(ifile) = ftype_amsua
-   case ( 'NC021027' )
-      ftype(ifile) = ftype_mhs
-   case ( 'NC021249' )
-      ftype(ifile) = ftype_airs
-   case ( 'NC021241' )
-      ftype(ifile) = ftype_iasi
-   case ( 'NC021202', 'NC021206' )
-      ftype(ifile) = ftype_cris
-   case default
-      ftype(ifile) = ftype_unknown
-   end select
-   end if
-   call closbf(iunit)
-   close(iunit)
-end do fileloop
-
-end subroutine parse_files_to_convert
 
 end program obs2ioda

--- a/obs2ioda-v2/src/ncio_mod.f90
+++ b/obs2ioda-v2/src/ncio_mod.f90
@@ -4,10 +4,10 @@ use netcdf
 use kinds, only: i_kind, r_single, r_kind
 use define_mod, only: nobtype, nvar_info, n_ncdim, n_ncgrp, nstring, ndatetime, &
    obtype_list, name_ncdim, name_ncgrp, name_var_met, name_var_info, name_sen_info, &
-   xdata, itrue, ifalse, vflag, ninst, inst_list, write_nc_conv, write_nc_radiance, &
+   itrue, ifalse, vflag, ninst, inst_list, write_nc_conv, write_nc_radiance, &
    write_nc_radiance_geo, ninst_geo, geoinst_list, &
    var_tb, nsen_info, type_var_info, type_sen_info, dim_var_info, dim_sen_info, &
-   unit_var_met, iflag_conv, iflag_radiance, set_brit_obserr, set_ahi_obserr
+   unit_var_met, iflag_conv, iflag_radiance, set_brit_obserr, set_ahi_obserr, xdata_type
 use netcdf_mod, only: open_netcdf_for_write, close_netcdf, &
    def_netcdf_dims, def_netcdf_grp, def_netcdf_var, def_netcdf_end, &
    put_netcdf_var, get_netcdf_dims
@@ -20,7 +20,7 @@ public :: write_obs
 
 contains
 
-subroutine write_obs (filedate, write_opt, outdir, itim)
+subroutine write_obs (filedate, write_opt, outdir, itim, xdata)
 
    implicit none
 
@@ -28,6 +28,8 @@ subroutine write_obs (filedate, write_opt, outdir, itim)
    integer(i_kind),  intent(in)          :: write_opt
    character(len=*), intent(in)          :: outdir
    integer(i_kind),  intent(in)          :: itim
+   type(xdata_type), allocatable, dimension(:,:), intent(inout) :: xdata
+
 
    character(len=512)                    :: ncfname  ! netcdf file name
    integer(i_kind), dimension(n_ncdim)   :: ncid_ncdim

--- a/obs2ioda-v2/src/setup_mod.f90
+++ b/obs2ioda-v2/src/setup_mod.f90
@@ -1,197 +1,213 @@
 module setup_mod
-    use kinds, only: i_kind
-    use define_mod, only: StrLen
-    use core_mod, only: obs2ioda_args_t
+    use kinds, only : i_kind
+    use define_mod, only : StrLen
+    use core_mod, only : obs2ioda_args_t
     implicit none
 
-    contains
-        subroutine handle_user_input(obs2ioda_args, flist, ftype, nfile)
+contains
 
-            implicit none
-            type(obs2ioda_args_t), intent(inout) :: obs2ioda_args
-            character(len=obs2ioda_args%NameLen), dimension(:), intent(inout) :: flist
-            integer(i_kind), intent(out) :: nfile
-            integer(i_kind), dimension(:), intent(out) :: ftype
-            character(len=StrLen) :: tmp
+    subroutine set_command_line_arguments(command_line_arguments)
+        implicit none
+        character(len = StrLen), allocatable, dimension(:), intent(out) :: command_line_arguments
+        integer(i_kind) :: arg_count
+        integer(i_kind) :: i
+        arg_count = command_argument_count()
+        allocate(command_line_arguments(arg_count))
+        if (arg_count > 0) then
+            do i = 1, arg_count
+                call get_command_argument(i, command_line_arguments(i))
+            end do
+        end if
+    end subroutine set_command_line_arguments
 
-            integer(i_kind)       :: iunit = 21
-            integer(i_kind)       :: narg, iarg, iarg_inpdir, iarg_outdir, iarg_datetime, iarg_subsample, iarg_superob_halfwidth,&
-                    ifile
-            integer(i_kind)       :: itmp
-            integer(i_kind)       :: iost, iret, idate
-            character(len=StrLen) :: strtmp
-            character(len=8)      :: subset
+    subroutine handle_user_input(obs2ioda_args, flist, ftype, nfile, command_line_arguments)
 
-            narg = command_argument_count()
-            ifile = 0
-            obs2ioda_args%inpdir = '.'
-            obs2ioda_args%outdir = '.'
-            obs2ioda_args%cdatetime = ''
-            flist(:) = 'null'
-            iarg_inpdir = -1
-            iarg_outdir = -1
-            iarg_datetime = -1
-            iarg_subsample = -1
-            iarg_superob_halfwidth = -1
-            if ( narg > 0 ) then
-                do iarg = 1, narg
-                    call get_command_argument(number=iarg, value=strtmp)
-                    if ( trim(strtmp) == '-qc' ) then
-                        obs2ioda_args%apply_gsi_qc = .true.
-                    else if ( trim(strtmp) == '-noqc' ) then
-                        obs2ioda_args%apply_gsi_qc = .false.
-                    else if ( trim(strtmp) == '-tv' ) then
-                        obs2ioda_args%do_tv_to_ts = .false.
-                    else if ( trim(strtmp) == '-ahi' ) then
-                        obs2ioda_args%do_ahi = .true.
-                    else if ( trim(strtmp) == '-split' ) then
-                        obs2ioda_args%time_split = .true.
-                    else if ( trim(strtmp) == '-i' ) then
-                        iarg_inpdir = iarg + 1
-                    else if ( trim(strtmp) == '-o' ) then
-                        iarg_outdir = iarg + 1
-                    else if ( trim(strtmp) == '-t' ) then
-                        iarg_datetime = iarg + 1
-                    else if ( trim(strtmp) == '-s' ) then
-                        iarg_subsample = iarg + 1
-                    else if ( trim(strtmp) == '-superob' ) then
-                        obs2ioda_args%do_superob = .true.
-                        iarg_superob_halfwidth = iarg + 1
-                    else
-                        if ( iarg == iarg_inpdir ) then
-                            call get_command_argument(number=iarg, value=tmp)
-                            obs2ioda_args%inpdir = trim(tmp)
-                        else if ( iarg == iarg_outdir ) then
-                            call get_command_argument(number=iarg, value=tmp)
-                            obs2ioda_args%outdir = trim(tmp)
-                        else if ( iarg == iarg_datetime ) then
-                            call get_command_argument(number=iarg, value=tmp)
-                            obs2ioda_args%cdatetime = trim(tmp)
-                        else if ( iarg == iarg_subsample ) then
-                            call get_command_argument(number=iarg, value=strtmp)
-                            if ( len_trim(strtmp) > 0 ) then
-                                read(strtmp,'(i2)') obs2ioda_args%subsample
-                            else
-                                obs2ioda_args%subsample = 1
-                            end if
-                        else if ( iarg == iarg_superob_halfwidth ) then
-                            call get_command_argument(number=iarg, value=strtmp)
-                            if ( len_trim(strtmp) > 0 ) then
-                                read(strtmp,'(i2)') obs2ioda_args%superob_halfwidth
-                            else
-                                obs2ioda_args%superob_halfwidth = 1
-                            end if
-                        else
-                            ifile = ifile + 1
-                            call get_command_argument(number=iarg, value=flist(ifile))
-                        end if
-                    end if
-                end do
-                if ( ifile == 0 ) then
-                    nfile = obs2ioda_args%nfile_all
-                    flist(:) = obs2ioda_args%flist_all(:)
-                    ftype(:) = (/ obs2ioda_args%ftype_gnssro, obs2ioda_args%ftype_prepbufr, obs2ioda_args%ftype_satwnd,  &
-                            obs2ioda_args%ftype_amsua, obs2ioda_args%ftype_airs, obs2ioda_args%ftype_mhs,  &
-                            obs2ioda_args%ftype_iasi, obs2ioda_args%ftype_cris /)
+        implicit none
+        type(obs2ioda_args_t), intent(inout) :: obs2ioda_args
+        character(len = obs2ioda_args%NameLen), dimension(:), intent(inout) :: flist
+        integer(i_kind), intent(out) :: nfile
+        integer(i_kind), dimension(:), intent(out) :: ftype
+        character(len = StrLen), allocatable, dimension(:), intent(in) :: command_line_arguments
+        character(len = StrLen) :: tmp
+
+        integer(i_kind) :: iunit = 21
+        integer(i_kind) :: narg, iarg, iarg_inpdir, iarg_outdir, iarg_datetime, iarg_subsample, iarg_superob_halfwidth, &
+                ifile
+        integer(i_kind) :: itmp
+        integer(i_kind) :: iost, iret, idate
+        character(len = StrLen) :: strtmp
+        character(len = 8) :: subset
+
+        narg = size(command_line_arguments)
+        ifile = 0
+        obs2ioda_args%inpdir = '.'
+        obs2ioda_args%outdir = '.'
+        obs2ioda_args%cdatetime = ''
+        flist(:) = 'null'
+        iarg_inpdir = -1
+        iarg_outdir = -1
+        iarg_datetime = -1
+        iarg_subsample = -1
+        iarg_superob_halfwidth = -1
+        if (narg > 0) then
+            do iarg = 1, narg
+                strtmp = command_line_arguments(iarg)
+                if (trim(strtmp) == '-qc') then
+                    obs2ioda_args%apply_gsi_qc = .true.
+                else if (trim(strtmp) == '-noqc') then
+                    obs2ioda_args%apply_gsi_qc = .false.
+                else if (trim(strtmp) == '-tv') then
+                    obs2ioda_args%do_tv_to_ts = .false.
+                else if (trim(strtmp) == '-ahi') then
+                    obs2ioda_args%do_ahi = .true.
+                else if (trim(strtmp) == '-split') then
+                    obs2ioda_args%time_split = .true.
+                else if (trim(strtmp) == '-i') then
+                    iarg_inpdir = iarg + 1
+                else if (trim(strtmp) == '-o') then
+                    iarg_outdir = iarg + 1
+                else if (trim(strtmp) == '-t') then
+                    iarg_datetime = iarg + 1
+                else if (trim(strtmp) == '-s') then
+                    iarg_subsample = iarg + 1
+                else if (trim(strtmp) == '-superob') then
+                    obs2ioda_args%do_superob = .true.
+                    iarg_superob_halfwidth = iarg + 1
                 else
-                    nfile = ifile
+                    if (iarg == iarg_inpdir) then
+                        tmp = command_line_arguments(iarg)
+                        obs2ioda_args%inpdir = trim(tmp)
+                    else if (iarg == iarg_outdir) then
+                        tmp = command_line_arguments(iarg)
+                        obs2ioda_args%outdir = trim(tmp)
+                    else if (iarg == iarg_datetime) then
+                        tmp = command_line_arguments(iarg)
+                        obs2ioda_args%cdatetime = trim(tmp)
+                    else if (iarg == iarg_subsample) then
+                        strtmp = command_line_arguments(iarg)
+                        if (len_trim(strtmp) > 0) then
+                            read(strtmp, '(i2)') obs2ioda_args%subsample
+                        else
+                            obs2ioda_args%subsample = 1
+                        end if
+                    else if (iarg == iarg_superob_halfwidth) then
+                        strtmp = command_line_arguments(iarg)
+                        if (len_trim(strtmp) > 0) then
+                            read(strtmp, '(i2)') obs2ioda_args%superob_halfwidth
+                        else
+                            obs2ioda_args%superob_halfwidth = 1
+                        end if
+                    else
+                        ifile = ifile + 1
+                        flist(ifile) = command_line_arguments(iarg)
+                    end if
                 end if
-            else
-                obs2ioda_args%inpdir = '.'
-                obs2ioda_args%outdir = '.'
+            end do
+            if (ifile == 0) then
                 nfile = obs2ioda_args%nfile_all
                 flist(:) = obs2ioda_args%flist_all(:)
-                ftype(:) = (/ obs2ioda_args%ftype_gnssro, obs2ioda_args%ftype_prepbufr, obs2ioda_args%ftype_satwnd,  &
-                        obs2ioda_args%ftype_amsua, obs2ioda_args%ftype_airs, obs2ioda_args%ftype_mhs,  &
+                ftype(:) = (/ obs2ioda_args%ftype_gnssro, obs2ioda_args%ftype_prepbufr, obs2ioda_args%ftype_satwnd, &
+                        obs2ioda_args%ftype_amsua, obs2ioda_args%ftype_airs, obs2ioda_args%ftype_mhs, &
                         obs2ioda_args%ftype_iasi, obs2ioda_args%ftype_cris /)
-            end if
-
-            itmp = len_trim(obs2ioda_args%inpdir)
-            if ( obs2ioda_args%inpdir(itmp:itmp) /= '/' ) obs2ioda_args%inpdir = trim(obs2ioda_args%inpdir)//'/'
-            itmp = len_trim(obs2ioda_args%outdir)
-            if ( obs2ioda_args%outdir(itmp:itmp) /= '/' ) obs2ioda_args%outdir = trim(obs2ioda_args%outdir)//'/'
-
-            ! use default file lists if not set in command-line arguemnt
-            if ( narg == 0 .or. ifile == 0 ) return
-
-        end subroutine handle_user_input
-
-        subroutine set_nfgat(obs2ioda_args)
-            implicit none
-            type(obs2ioda_args_t), intent(inout) :: obs2ioda_args
-            if ( obs2ioda_args%time_split ) then
-                obs2ioda_args%hour_fgat = 1  ! can also be 3 or 2
-                ! corresponding to dtime_min='-3h' and dtime_max='+3h'
-                obs2ioda_args%nfgat = (6/obs2ioda_args%hour_fgat) + 1
             else
-                obs2ioda_args%nfgat = 1
+                nfile = ifile
             end if
-        end subroutine set_nfgat
+        else
+            obs2ioda_args%inpdir = '.'
+            obs2ioda_args%outdir = '.'
+            nfile = obs2ioda_args%nfile_all
+            flist(:) = obs2ioda_args%flist_all(:)
+            ftype(:) = (/ obs2ioda_args%ftype_gnssro, obs2ioda_args%ftype_prepbufr, obs2ioda_args%ftype_satwnd, &
+                    obs2ioda_args%ftype_amsua, obs2ioda_args%ftype_airs, obs2ioda_args%ftype_mhs, &
+                    obs2ioda_args%ftype_iasi, obs2ioda_args%ftype_cris /)
+        end if
 
-        subroutine parse_files_to_convert(obs2ioda_args, flist, ftype, nfile)
+        itmp = len_trim(obs2ioda_args%inpdir)
+        if (obs2ioda_args%inpdir(itmp:itmp) /= '/') obs2ioda_args%inpdir = trim(obs2ioda_args%inpdir) // '/'
+        itmp = len_trim(obs2ioda_args%outdir)
+        if (obs2ioda_args%outdir(itmp:itmp) /= '/') obs2ioda_args%outdir = trim(obs2ioda_args%outdir) // '/'
+        write(*, *) 'Input directory: ', trim(obs2ioda_args%inpdir)
+        ! use default file lists if not set in command-line arguemnt
+        if (narg == 0 .or. ifile == 0) return
 
-            implicit none
-            type(obs2ioda_args_t), intent(in) :: obs2ioda_args
-            character(len=obs2ioda_args%NameLen), dimension(:), intent(inout) :: flist
-            integer(i_kind), intent(in) :: nfile
-            integer(i_kind), dimension(:), intent(inout) :: ftype
-            character(len=StrLen) :: tmp
+    end subroutine handle_user_input
 
-            integer(i_kind)       :: iunit = 21
-            integer(i_kind)       :: narg, iarg, iarg_inpdir, iarg_outdir, iarg_datetime, iarg_subsample, iarg_superob_halfwidth,&
-                    ifile
-            integer(i_kind)       :: itmp
-            integer(i_kind)       :: iost, iret, idate
-            character(len=StrLen) :: strtmp
-            character(len=8)      :: subset
+    subroutine set_nfgat(obs2ioda_args)
+        implicit none
+        type(obs2ioda_args_t), intent(inout) :: obs2ioda_args
+        if (obs2ioda_args%time_split) then
+            obs2ioda_args%hour_fgat = 1  ! can also be 3 or 2
+            ! corresponding to dtime_min='-3h' and dtime_max='+3h'
+            obs2ioda_args%nfgat = (6 / obs2ioda_args%hour_fgat) + 1
+        else
+            obs2ioda_args%nfgat = 1
+        end if
+    end subroutine set_nfgat
 
-            ! determine the input file type
-            fileloop: do ifile = 1, nfile
-                if ( trim(flist(ifile)) == 'null' ) then
+    subroutine parse_files_to_convert(obs2ioda_args, flist, ftype, nfile)
+
+        implicit none
+        type(obs2ioda_args_t), intent(in) :: obs2ioda_args
+        character(len = obs2ioda_args%NameLen), dimension(:), intent(inout) :: flist
+        integer(i_kind), intent(in) :: nfile
+        integer(i_kind), dimension(:), intent(inout) :: ftype
+        character(len = StrLen) :: tmp
+
+        integer(i_kind) :: iunit = 21
+        integer(i_kind) :: narg, iarg, iarg_inpdir, iarg_outdir, iarg_datetime, iarg_subsample, iarg_superob_halfwidth, &
+                ifile
+        integer(i_kind) :: itmp
+        integer(i_kind) :: iost, iret, idate
+        character(len = StrLen) :: strtmp
+        character(len = 8) :: subset
+
+        ! determine the input file type
+        fileloop : do ifile = 1, nfile
+            if (trim(flist(ifile)) == 'null') then
+                ftype(ifile) = obs2ioda_args%ftype_unknown
+                cycle fileloop
+            end if
+            open(unit = iunit, file = trim(obs2ioda_args%inpdir) // trim(flist(ifile)), form = 'unformatted', iostat = iost, status = 'old')
+            call openbf(iunit, 'IN', iunit)
+            call readmg(iunit, subset, idate, iret)
+            !print*,subset
+            if (subset(1:5) == 'NC005') then
+                ftype(ifile) = obs2ioda_args%ftype_satwnd
+            else
+                select case (trim(subset))
+                case ('ADPUPA', 'ADPSFC')
+                    ftype(ifile) = obs2ioda_args%ftype_prepbufr
+                case ('NC003010')
+                    ftype(ifile) = obs2ioda_args%ftype_gnssro
+                case ('NC021023')
+                    ftype(ifile) = obs2ioda_args%ftype_amsua
+                case ('NC021027')
+                    ftype(ifile) = obs2ioda_args%ftype_mhs
+                case ('NC021249')
+                    ftype(ifile) = obs2ioda_args%ftype_airs
+                case ('NC021241')
+                    ftype(ifile) = obs2ioda_args%ftype_iasi
+                case ('NC021202', 'NC021206')
+                    ftype(ifile) = obs2ioda_args%ftype_cris
+                case default
                     ftype(ifile) = obs2ioda_args%ftype_unknown
-                    cycle fileloop
-                end if
-                open(unit=iunit, file=trim(obs2ioda_args%inpdir)//trim(flist(ifile)), form='unformatted', iostat=iost, status='old')
-                call openbf(iunit, 'IN', iunit)
-                call readmg(iunit,subset,idate,iret)
-                !print*,subset
-                if ( subset(1:5) == 'NC005' ) then
-                    ftype(ifile) = obs2ioda_args%ftype_satwnd
-                else
-                    select case ( trim(subset) )
-                    case (  'ADPUPA', 'ADPSFC' )
-                        ftype(ifile) = obs2ioda_args%ftype_prepbufr
-                    case ( 'NC003010' )
-                        ftype(ifile) = obs2ioda_args%ftype_gnssro
-                    case ( 'NC021023' )
-                        ftype(ifile) = obs2ioda_args%ftype_amsua
-                    case ( 'NC021027' )
-                        ftype(ifile) = obs2ioda_args%ftype_mhs
-                    case ( 'NC021249' )
-                        ftype(ifile) = obs2ioda_args%ftype_airs
-                    case ( 'NC021241' )
-                        ftype(ifile) = obs2ioda_args%ftype_iasi
-                    case ( 'NC021202', 'NC021206' )
-                        ftype(ifile) = obs2ioda_args%ftype_cris
-                    case default
-                        ftype(ifile) = obs2ioda_args%ftype_unknown
-                    end select
-                end if
-                call closbf(iunit)
-                close(iunit)
-            end do fileloop
-        end subroutine parse_files_to_convert
-
-        logical function input_file_exists(obs2ioda_args)
-            type(obs2ioda_args_t), intent(in) :: obs2ioda_args
-            logical :: fexist
-
-            inquire(file=trim(obs2ioda_args%inpdir)//trim(obs2ioda_args%filename), exist=fexist)
-            if ( .not. fexist ) then
-                write(*,*) 'Warning: ',trim(obs2ioda_args%inpdir)//trim(obs2ioda_args%filename), ' not found for decoding...'
-                input_file_exists = .false.
-            else
-                input_file_exists = .true.
+                end select
             end if
-        end function input_file_exists
+            call closbf(iunit)
+            close(iunit)
+        end do fileloop
+    end subroutine parse_files_to_convert
+
+    logical function input_file_exists(obs2ioda_args)
+        type(obs2ioda_args_t), intent(in) :: obs2ioda_args
+        logical :: fexist
+
+        inquire(file = trim(obs2ioda_args%inpdir) // trim(obs2ioda_args%filename), exist = fexist)
+        if (.not. fexist) then
+            write(*, *) 'Warning: ', trim(obs2ioda_args%inpdir) // trim(obs2ioda_args%filename), ' not found for decoding...'
+            input_file_exists = .false.
+        else
+            input_file_exists = .true.
+        end if
+    end function input_file_exists
 end module setup_mod

--- a/obs2ioda-v2/src/setup_mod.f90
+++ b/obs2ioda-v2/src/setup_mod.f90
@@ -1,0 +1,197 @@
+module setup_mod
+    use kinds, only: i_kind
+    use define_mod, only: StrLen
+    use core_mod, only: obs2ioda_args_t
+    implicit none
+
+    contains
+        subroutine handle_user_input(obs2ioda_args, flist, ftype, nfile)
+
+            implicit none
+            type(obs2ioda_args_t), intent(inout) :: obs2ioda_args
+            character(len=obs2ioda_args%NameLen), dimension(:), intent(inout) :: flist
+            integer(i_kind), intent(out) :: nfile
+            integer(i_kind), dimension(:), intent(out) :: ftype
+            character(len=StrLen) :: tmp
+
+            integer(i_kind)       :: iunit = 21
+            integer(i_kind)       :: narg, iarg, iarg_inpdir, iarg_outdir, iarg_datetime, iarg_subsample, iarg_superob_halfwidth,&
+                    ifile
+            integer(i_kind)       :: itmp
+            integer(i_kind)       :: iost, iret, idate
+            character(len=StrLen) :: strtmp
+            character(len=8)      :: subset
+
+            narg = command_argument_count()
+            ifile = 0
+            obs2ioda_args%inpdir = '.'
+            obs2ioda_args%outdir = '.'
+            obs2ioda_args%cdatetime = ''
+            flist(:) = 'null'
+            iarg_inpdir = -1
+            iarg_outdir = -1
+            iarg_datetime = -1
+            iarg_subsample = -1
+            iarg_superob_halfwidth = -1
+            if ( narg > 0 ) then
+                do iarg = 1, narg
+                    call get_command_argument(number=iarg, value=strtmp)
+                    if ( trim(strtmp) == '-qc' ) then
+                        obs2ioda_args%apply_gsi_qc = .true.
+                    else if ( trim(strtmp) == '-noqc' ) then
+                        obs2ioda_args%apply_gsi_qc = .false.
+                    else if ( trim(strtmp) == '-tv' ) then
+                        obs2ioda_args%do_tv_to_ts = .false.
+                    else if ( trim(strtmp) == '-ahi' ) then
+                        obs2ioda_args%do_ahi = .true.
+                    else if ( trim(strtmp) == '-split' ) then
+                        obs2ioda_args%time_split = .true.
+                    else if ( trim(strtmp) == '-i' ) then
+                        iarg_inpdir = iarg + 1
+                    else if ( trim(strtmp) == '-o' ) then
+                        iarg_outdir = iarg + 1
+                    else if ( trim(strtmp) == '-t' ) then
+                        iarg_datetime = iarg + 1
+                    else if ( trim(strtmp) == '-s' ) then
+                        iarg_subsample = iarg + 1
+                    else if ( trim(strtmp) == '-superob' ) then
+                        obs2ioda_args%do_superob = .true.
+                        iarg_superob_halfwidth = iarg + 1
+                    else
+                        if ( iarg == iarg_inpdir ) then
+                            call get_command_argument(number=iarg, value=tmp)
+                            obs2ioda_args%inpdir = trim(tmp)
+                        else if ( iarg == iarg_outdir ) then
+                            call get_command_argument(number=iarg, value=tmp)
+                            obs2ioda_args%outdir = trim(tmp)
+                        else if ( iarg == iarg_datetime ) then
+                            call get_command_argument(number=iarg, value=tmp)
+                            obs2ioda_args%cdatetime = trim(tmp)
+                        else if ( iarg == iarg_subsample ) then
+                            call get_command_argument(number=iarg, value=strtmp)
+                            if ( len_trim(strtmp) > 0 ) then
+                                read(strtmp,'(i2)') obs2ioda_args%subsample
+                            else
+                                obs2ioda_args%subsample = 1
+                            end if
+                        else if ( iarg == iarg_superob_halfwidth ) then
+                            call get_command_argument(number=iarg, value=strtmp)
+                            if ( len_trim(strtmp) > 0 ) then
+                                read(strtmp,'(i2)') obs2ioda_args%superob_halfwidth
+                            else
+                                obs2ioda_args%superob_halfwidth = 1
+                            end if
+                        else
+                            ifile = ifile + 1
+                            call get_command_argument(number=iarg, value=flist(ifile))
+                        end if
+                    end if
+                end do
+                if ( ifile == 0 ) then
+                    nfile = obs2ioda_args%nfile_all
+                    flist(:) = obs2ioda_args%flist_all(:)
+                    ftype(:) = (/ obs2ioda_args%ftype_gnssro, obs2ioda_args%ftype_prepbufr, obs2ioda_args%ftype_satwnd,  &
+                            obs2ioda_args%ftype_amsua, obs2ioda_args%ftype_airs, obs2ioda_args%ftype_mhs,  &
+                            obs2ioda_args%ftype_iasi, obs2ioda_args%ftype_cris /)
+                else
+                    nfile = ifile
+                end if
+            else
+                obs2ioda_args%inpdir = '.'
+                obs2ioda_args%outdir = '.'
+                nfile = obs2ioda_args%nfile_all
+                flist(:) = obs2ioda_args%flist_all(:)
+                ftype(:) = (/ obs2ioda_args%ftype_gnssro, obs2ioda_args%ftype_prepbufr, obs2ioda_args%ftype_satwnd,  &
+                        obs2ioda_args%ftype_amsua, obs2ioda_args%ftype_airs, obs2ioda_args%ftype_mhs,  &
+                        obs2ioda_args%ftype_iasi, obs2ioda_args%ftype_cris /)
+            end if
+
+            itmp = len_trim(obs2ioda_args%inpdir)
+            if ( obs2ioda_args%inpdir(itmp:itmp) /= '/' ) obs2ioda_args%inpdir = trim(obs2ioda_args%inpdir)//'/'
+            itmp = len_trim(obs2ioda_args%outdir)
+            if ( obs2ioda_args%outdir(itmp:itmp) /= '/' ) obs2ioda_args%outdir = trim(obs2ioda_args%outdir)//'/'
+
+            ! use default file lists if not set in command-line arguemnt
+            if ( narg == 0 .or. ifile == 0 ) return
+
+        end subroutine handle_user_input
+
+        subroutine set_nfgat(obs2ioda_args)
+            implicit none
+            type(obs2ioda_args_t), intent(inout) :: obs2ioda_args
+            if ( obs2ioda_args%time_split ) then
+                obs2ioda_args%hour_fgat = 1  ! can also be 3 or 2
+                ! corresponding to dtime_min='-3h' and dtime_max='+3h'
+                obs2ioda_args%nfgat = (6/obs2ioda_args%hour_fgat) + 1
+            else
+                obs2ioda_args%nfgat = 1
+            end if
+        end subroutine set_nfgat
+
+        subroutine parse_files_to_convert(obs2ioda_args, flist, ftype, nfile)
+
+            implicit none
+            type(obs2ioda_args_t), intent(in) :: obs2ioda_args
+            character(len=obs2ioda_args%NameLen), dimension(:), intent(inout) :: flist
+            integer(i_kind), intent(in) :: nfile
+            integer(i_kind), dimension(:), intent(inout) :: ftype
+            character(len=StrLen) :: tmp
+
+            integer(i_kind)       :: iunit = 21
+            integer(i_kind)       :: narg, iarg, iarg_inpdir, iarg_outdir, iarg_datetime, iarg_subsample, iarg_superob_halfwidth,&
+                    ifile
+            integer(i_kind)       :: itmp
+            integer(i_kind)       :: iost, iret, idate
+            character(len=StrLen) :: strtmp
+            character(len=8)      :: subset
+
+            ! determine the input file type
+            fileloop: do ifile = 1, nfile
+                if ( trim(flist(ifile)) == 'null' ) then
+                    ftype(ifile) = obs2ioda_args%ftype_unknown
+                    cycle fileloop
+                end if
+                open(unit=iunit, file=trim(obs2ioda_args%inpdir)//trim(flist(ifile)), form='unformatted', iostat=iost, status='old')
+                call openbf(iunit, 'IN', iunit)
+                call readmg(iunit,subset,idate,iret)
+                !print*,subset
+                if ( subset(1:5) == 'NC005' ) then
+                    ftype(ifile) = obs2ioda_args%ftype_satwnd
+                else
+                    select case ( trim(subset) )
+                    case (  'ADPUPA', 'ADPSFC' )
+                        ftype(ifile) = obs2ioda_args%ftype_prepbufr
+                    case ( 'NC003010' )
+                        ftype(ifile) = obs2ioda_args%ftype_gnssro
+                    case ( 'NC021023' )
+                        ftype(ifile) = obs2ioda_args%ftype_amsua
+                    case ( 'NC021027' )
+                        ftype(ifile) = obs2ioda_args%ftype_mhs
+                    case ( 'NC021249' )
+                        ftype(ifile) = obs2ioda_args%ftype_airs
+                    case ( 'NC021241' )
+                        ftype(ifile) = obs2ioda_args%ftype_iasi
+                    case ( 'NC021202', 'NC021206' )
+                        ftype(ifile) = obs2ioda_args%ftype_cris
+                    case default
+                        ftype(ifile) = obs2ioda_args%ftype_unknown
+                    end select
+                end if
+                call closbf(iunit)
+                close(iunit)
+            end do fileloop
+        end subroutine parse_files_to_convert
+
+        logical function input_file_exists(obs2ioda_args)
+            type(obs2ioda_args_t), intent(in) :: obs2ioda_args
+            logical :: fexist
+
+            inquire(file=trim(obs2ioda_args%inpdir)//trim(obs2ioda_args%filename), exist=fexist)
+            if ( .not. fexist ) then
+                write(*,*) 'Warning: ',trim(obs2ioda_args%inpdir)//trim(obs2ioda_args%filename), ' not found for decoding...'
+                input_file_exists = .false.
+            else
+                input_file_exists = .true.
+            end if
+        end function input_file_exists
+end module setup_mod

--- a/obs2ioda-v2/src/utils_mod.f90
+++ b/obs2ioda-v2/src/utils_mod.f90
@@ -3,12 +3,14 @@ module utils_mod
 ! adapated from WRFDA/var/da/da_tools/da_advance_time.inc
 
 use kinds, only: r_kind,i_kind,r_double, i_llong
+use core_mod, only: obs2ioda_args_t
 
 implicit none
 private
 public :: da_advance_time
 public :: get_julian_time
 public :: da_get_time_slots
+
 
 contains
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/fortran")

--- a/tests/fortran/CMakeLists.txt
+++ b/tests/fortran/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Specify Fortran standard
+enable_language(Fortran)
+
+# Include pFUnit's Fortran compiler wrapper
+include(FortranCInterface)
+FortranCInterface_VERIFY()
+include_directories(${PFUNIT_INCLUDE_DIRS})
+include_directories(${CMAKE_SOURCE_DIR}/build)
+
+add_pfunit_ctest(Test_handle_user_input_mod
+                 TEST_SOURCES Test_handle_user_input_mod.pf
+                 LINK_LIBRARIES v2
+)

--- a/tests/fortran/Test_handle_user_input_mod.pf
+++ b/tests/fortran/Test_handle_user_input_mod.pf
@@ -1,0 +1,39 @@
+module Test_handle_user_input_mod
+    use funit
+    use setup_mod, only: handle_user_input
+    use core_mod, only: obs2ioda_args_t
+    use define_mod, only: StrLen
+    use kinds, only: i_kind
+    implicit none
+
+contains
+
+    @Test
+    subroutine test_handle_user_input()
+        character(len=StrLen), dimension(:), allocatable :: command_line_args
+        type(obs2ioda_args_t) :: obs2ioda_args
+        character (len=64) :: flist(8)  ! file names to be read in from command line arguments
+        integer(i_kind)            :: ftype(8)
+        integer(i_kind)         :: nfile, flist_size
+        character(len=StrLen) :: tmp
+
+        allocate(command_line_args(4))
+        tmp = "-i "
+        command_line_args(1) = adjustl(tmp)
+        tmp = "./input/ "
+        command_line_args(2) = adjustl(tmp)
+        tmp = "-o "
+        command_line_args(3) = adjustl(tmp)
+        tmp = "./output/ "
+        command_line_args(4) = adjustl(tmp)
+
+
+        call handle_user_input(obs2ioda_args,flist, ftype, nfile, command_line_args)
+        flist_size = size(flist)
+        @assertEqual("./input/",trim(obs2ioda_args%inpdir))
+        @assertEqual("./output/",trim(obs2ioda_args%outdir))
+
+    end subroutine test_handle_user_input
+
+end module Test_handle_user_input_mod
+


### PR DESCRIPTION
This PR refactors `main.f90` to function as a utility program rather than a core part of the code's calculations. While this may seem minor, it improves the testability of the `obs2ioda` code base and enhances memory safety by reducing global memory usage. Notably, this refactor exposed a significant out-of-bounds array error in the `ncio` module. 

I still need to rebase this on the latest `main` branch to incorporate recent CMake changes. This PR does not include the C++ refactoring required for ioda3 format support. However, merging these changes first will simplify that upcoming PR.