### PR TITLE
Integrate pFUnit Framework for Fortran Unit Testing in obs2ioda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Check CMake version
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 include("${CMAKE_SOURCE_DIR}/cmake/Functions/Obs2Ioda_Functions.cmake")
 # Define the project
@@ -14,10 +14,21 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/${OBS2IODA_MODULE_DIR}/ DESTINATION ${CMAK
 
 
 # Set the Fortran compiler and flags
-set(NCEP_BUFR_LIB CACHE STRING "" )
+set(NCEP_BUFR_LIB CACHE STRING "")
+option(BUILD_TESTS "Build tests" OFF)
+# Required if BUILD_TESTS is ON
+set(PFUNIT_DIR CACHE STRING "")
 
 # Find required packages
 find_package(NetCDF REQUIRED COMPONENTS Fortran C)
 
 add_subdirectory("${CMAKE_SOURCE_DIR}/obs2ioda-v2")
+
+
+if (BUILD_TESTS)
+    enable_testing()
+    set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${PFUNIT_DIR})
+    find_package(PFUNIT REQUIRED)
+    add_subdirectory("${CMAKE_SOURCE_DIR}/tests")
+endif ()
 

--- a/obs2ioda-v2/README.md
+++ b/obs2ioda-v2/README.md
@@ -146,6 +146,12 @@ The following steps guide you through the PFUNIT installation:
 The PFUNIT library is now installed and ready for use.
 ---
 
+## Writing Unit Tests
+### pFUnit
+`pFUnit` is a Fortran testing framework that allows you to write and run unit tests for your Fortran code. The framework
+uses a interface that is looks like a mix of the `googletest` and `pytest` testing frameworks. Tests are are marked with
+`@Test` and can be run with the `pfunit.x` executable.
+
 ## caveate
 
 NetCDF-Fortran interface does not allow reading/writing NF90_STRING, so ``station_id`` and ``variable_names`` are still

--- a/obs2ioda-v2/README.md
+++ b/obs2ioda-v2/README.md
@@ -145,13 +145,6 @@ The following steps guide you through the PFUNIT installation:
    ```
 
 The PFUNIT library is now installed and ready for use.
----
-
-## Writing Unit Tests
-### pFUnit
-`pFUnit` is a Fortran testing framework that allows you to write and run unit tests for your Fortran code. The framework
-uses a interface that is looks like a mix of the `googletest` and `pytest` testing frameworks. Tests are are marked with
-`@Test` and can be run with the `pfunit.x` executable.
 
 ## caveate
 

--- a/obs2ioda-v2/README.md
+++ b/obs2ioda-v2/README.md
@@ -1,64 +1,155 @@
 # obs2ioda-v2.x
+
 ## Installation
-obs2ioda-v2 utilizes CMake as its primary build system. Follow the steps below to build the project:
+
+This guide will walk you through the installation and build process of obs2ioda-v2, which uses CMake.
 
 ### Prerequisites
-Please make sure the following libraries are installed:
-- NetCDF
-- NCEP BUFR library. (Instructions for installing the NCEP BUFR library are provided in a subsequent section)
 
-If you have an environment preconfigured for `mpas-jedi`, simply source that environment prior to building `obs2ioda`.
+Before you start, ensure you have the following libraries installed:
+
+- NetCDF
+- NCEP BUFR (see subsequent section for installation instructions)
+- PFUNIT (optional, required for unit testing)
+
+If your environment is preconfigured for `mpas-jedi`, you can source that environment before commencing the build
+process of `obs2ioda`.
 
 ### Build Instructions
-1. First, clone the repository into your preferred directory (`<OBS2IODA_ROOT_DIR>`):
+
+Here are the steps to build the project:
+
+1. Clone the repository into your preferred directory (`<OBS2IODA_ROOT_DIR>`):
+
    ```bash
    git clone https://github.com/NCAR/obs2ioda.git <OBS2IODA_ROOT_DIR>
    ```
-2. Create a new directory `build` and navigate into it:
+
+2. Create a directory to build `obs2ioda` in (<`OBS2IODA_BUILD_DIR`>) and navigate into it:
+
    ```bash
-   mkdir build && cd build
+    mkdir <OBS2IODA_BUILD_DIR> && cd <OBS2IODA_BUILD_DIR>
    ```
-3. Locate the NCEP BUFR library by executing the following command in the `NCEP BUFR` library's build directory:
+
+3. Locate your NCEP BUFR library with the following command executed in the NCEP BUFR library's build directory:
+
    ```bash
    find . -name *libbufr*
    ```
-4. Next, run CMake to configure the build. Remember to specify the path to the NCEP BUFR library:
+
+4. Configure your build variables by setting `OBS2IODA_CMAKE_ARGS` to the NCEP BUFR library path:
+
    ```bash
-   cmake <OBS2IODA_ROOT_DIR> -DNCEP_BUFR_LIB=<NCEP_BUFR_LIB_PATH>
+    export OBS2IODA_CMAKE_ARGS="-DNCEP_BUFR_LIB=<NCEP_BUFR_LIB_PATH>"
    ```
-5. Finally, build the project using this command:
+
+5. Enable unit testing (Optional) by adding:
+
    ```bash
-   make
+    export OBS2IODA_CMAKE_ARGS="${OBS2IODA_CMAKE_ARGS} -DBUILD_TESTING=ON -DPFUNIT_DIR"
    ```
-The `obs2ioda-v2` executable will reside in the `bin` directory within the build directory.
+
+6. Configure the build with CMake:
+
+   ```bash
+   cmake <OBS2IODA_ROOT_DIR> ${OBS2IODA_CMAKE_ARGS} 
+   ```
+
+7. Build the project:
+
+   ```bash
+   make -j
+   ```
+   
+8. Run the unit tests (Optional):
+
+   ```bash
+   ctest
+   ```
+
+After a successful build, you will find the `obs2ioda-v2` executable in the `bin` directory within the build directory.
 
 ---
+
 ## Installing NCEP BUFR Library
+
 To install the NCEP BUFR library, follow these steps:
 
 1. Clone the NCEP BUFR repository into a directory of your choice (`<NCEP_BUFR_ROOT_DIR>`):
    ```bash
    git clone https://github.com/NOAA-EMC/NCEPLIBS-bufr.git <NCEP_BUFR_ROOT_DIR>
    ```
-2. Create a new directory `build` and navigate into it:
+
+1. Create a new directory to build `NCEP BUFR` in (`<NCEP_BUFR_BUILD_DIR>`) and navigate into it:
+
    ```bash
-   mkdir build && cd build
+   mkdir <NCEP_BUFR_BUILD_DIR> && cd <NCEP_BUFR_BUILD_DIR>
    ```
-3. Run CMake to configure the build (Ensure NetCDF is installed):
+1. Run CMake to configure the build (Ensure NetCDF is installed):
    ```bash
    cmake <NCEP_BUFR_ROOT_DIR>
    ```
-4. Build the library with the command:
+1. Build the library with the command:
    ```bash
-   make
+   make -j
    ```
-5. To locate the NCEP BUFR library, run:
+1. Set the `NCEP_BUFR_LIB_PATH` environment variable to point to the directory where the NCEP BUFR library is installed:
    ```bash
-   find . -name *libbufr*
+   export NCEP_BUFR_LIB_PATH=$(find . -name *libbufr*)
    ```
-Remember to note down the library path (`<NCEP_BUFR_LIB_PATH>`) required for the build process of `obs2ioda-v2`.
+---
+
+## PFUNIT Installation (Optional)
+
+Before starting the installation of PFUNIT, verify if the paths to `gptl`, `gptl-shared`, or `fargparse` exist in
+your `CMAKE_PREFIX_PATH`. If present, you might need to temporarily remove them from your `CMAKE_PREFIX_PATH` prior to
+installing PFUNIT. Installation can fail obviously if this step is not taken.
+
+The following steps guide you through the PFUNIT installation:
+
+1. Clone the PFUNIT repository into a directory of your choice (`<PFUNIT_ROOT_DIR>`):
+
+   ```bash
+   git clone https://github.com/Goddard-Fortran-Ecosystem/pFUnit <PFUNIT_ROOT_DIR> -b v4.2.0 --recurse-submodules
+   ```
+
+2. Create a new directory to build `pFUnit` in (`<PFUNIT_BUILD_DIR>`) and navigate into it:
+
+   ```bash
+   mkdir <PFUNIT_BUILD_DIR> && cd <PFUNIT_BUILD_DIR>
+   ```
+
+3. Run CMake to configure the build:
+
+   ```bash
+   cmake <PFUNIT_ROOT_DIR>
+   ```
+
+4. Build the library:
+
+   ```bash
+   make -j
+   ```
+
+5. Install the library:
+
+   ```bash
+   make install
+   ```
+
+6. Set the `PFUNIT_DIR` environment variable to point to the directories where PFUNIT is installed:
+
+   ```bash
+   export PFUNIT_DIR=<PFUNIT_BUILD_DIR>
+   ```
+
+The PFUNIT library is now installed and ready for use.
+---
+
 ## caveate
-NetCDF-Fortran interface does not allow reading/writing NF90_STRING, so ``station_id`` and ``variable_names`` are still written out as  
+
+NetCDF-Fortran interface does not allow reading/writing NF90_STRING, so ``station_id`` and ``variable_names`` are still
+written out as  
 ``char station_id(nlocs, nstring)``  
 ``char variable_names(nvars, nstring)``  
 rather than  
@@ -66,104 +157,117 @@ rather than
 ``string variable_names(nvars)``
 
 ## Converting PREPBUFR and BUFR files
+
 ```
 Usage: obs2ioda-v2.x [-i input_dir] [-o output_dir] [bufr_filename(s)_to_convert] [-split]
 ```
+
 If [-i input_dir] [-o output_dir] are not specified in the command line, the default is the current working directory.  
-If [bufr_filename(s)_to_convert] is not specified in the command line, the code looks for file name, **prepbufr.bufr** (also **satwnd.bufr**, **gnssro.bufr**, **amsua.bufr**, **airs.bufr**, **mhs.bufr**, **iasi.bufr**, **cris.bufr**), in the input/working directory. If the file exists, do the conversion, otherwise skip it.  
+If [bufr_filename(s)_to_convert] is not specified in the command line, the code looks for file name, **prepbufr.bufr** (
+also **satwnd.bufr**, **gnssro.bufr**, **amsua.bufr**, **airs.bufr**, **mhs.bufr**, **iasi.bufr**, **cris.bufr**), in
+the input/working directory. If the file exists, do the conversion, otherwise skip it.  
 If specify ``-split``, the converted file will contain hourly data.
 
 > obs2ioda-v2.x -i input_dir -o output_dir prepbufr.gdas.YYYYMMDD.tHHz.nr
 
 Example output files (date in the output filename is extracted from the input bufr files):  
-  aircraft_obs_YYYYMMDDHH.h5  
-  ascat_obs_YYYYMMDDHH.h5  
-  profiler_obs_YYYYMMDDHH.h5  
-  satwind_obs_YYYYMMDDHH.h5  
-  sfc_obs_YYYYMMDDHH.h5  
-  sondes_obs_YYYYMMDDHH.h5  
+aircraft_obs_YYYYMMDDHH.h5  
+ascat_obs_YYYYMMDDHH.h5  
+profiler_obs_YYYYMMDDHH.h5  
+satwind_obs_YYYYMMDDHH.h5  
+sfc_obs_YYYYMMDDHH.h5  
+sondes_obs_YYYYMMDDHH.h5
 
 > obs2ioda-v2.x -i input_dir -o output_dir gdas.satwnd.tHHz.YYYYMMDD.bufr
 
 Example output files (date in the output filename is extracted from the input bufr files):  
-  satwnd_obs_YYYYMMDDHH.h5  (GOES-16/GOES-17, AVHRR (METOP/NOAA), VIIRS (NPP/NOAA), LEOGEO AMVs)  
-  
+satwnd_obs_YYYYMMDDHH.h5  (GOES-16/GOES-17, AVHRR (METOP/NOAA), VIIRS (NPP/NOAA), LEOGEO AMVs)
+
 > obs2ioda-v2.x -i input_dir -o output_dir gdas.1bamua.tHHz.YYYYMMDD.bufr
 
 Example output files:  
-  amsua_metop-a_obs_YYYYMMDDHH.h5  
-  amsua_metop-b_obs_YYYYMMDDHH.h5  
-  amsua_n15_obs_YYYYMMDDHH.h5  
-  amsua_n18_obs_YYYYMMDDHH.h5  
-  amsua_n19_obs_YYYYMMDDHH.h5  
+amsua_metop-a_obs_YYYYMMDDHH.h5  
+amsua_metop-b_obs_YYYYMMDDHH.h5  
+amsua_n15_obs_YYYYMMDDHH.h5  
+amsua_n18_obs_YYYYMMDDHH.h5  
+amsua_n19_obs_YYYYMMDDHH.h5
 
 > obs2ioda-v2.x -i input_dir -o output_dir gdas.airsev.tHHz.YYYYMMDD.bufr
 
 Example output files:  
-  amsua_aqua_obs_YYYYMMDDHH.h5  
+amsua_aqua_obs_YYYYMMDDHH.h5
 
 > obs2ioda-v2.x -i input_dir -o output_dir gdas.1bmhs.tHHz.YYYYMMDD.bufr
 
 Example output files:  
-  mhs_metop-a_obs_YYYYMMDDHH.h5  
-  mhs_metop-b_obs_YYYYMMDDHH.h5  
-  mhs_n18_obs_YYYYMMDDHH.h5  
-  mhs_n19_obs_YYYYMMDDHH.h5  
+mhs_metop-a_obs_YYYYMMDDHH.h5  
+mhs_metop-b_obs_YYYYMMDDHH.h5  
+mhs_n18_obs_YYYYMMDDHH.h5  
+mhs_n19_obs_YYYYMMDDHH.h5
 
 > obs2ioda-v2.x -i input_dir -o output_dir gdas.mtiasi.tHHz.YYYYMMDD.bufr
 
-**the following CRTM SpcCoeff files in little_endian must be present in the working directory for IASI radiance to brightness temperature conversion**  
+**the following CRTM SpcCoeff files in little_endian must be present in the working directory for IASI radiance to
+brightness temperature conversion**  
 iasi_metop-a.SpcCoeff.bin -> iasi616_metop-a.SpcCoeff.bin  
 iasi_metop-b.SpcCoeff.bin -> iasi616_metop-b.SpcCoeff.bin  
-iasi_metop-c.SpcCoeff.bin -> iasi616_metop-c.SpcCoeff.bin  
+iasi_metop-c.SpcCoeff.bin -> iasi616_metop-c.SpcCoeff.bin
 
 Example output files:  
-  iasi_metop-a_obs_YYYYMMDDHH.h5  
-  iasi_metop-b_obs_YYYYMMDDHH.h5  
-  iasi_metop-c_obs_YYYYMMDDHH.h5  
+iasi_metop-a_obs_YYYYMMDDHH.h5  
+iasi_metop-b_obs_YYYYMMDDHH.h5  
+iasi_metop-c_obs_YYYYMMDDHH.h5
 
 > obs2ioda-v2.x -i input_dir -o output_dir gdas.crisf4.tHHz.YYYYMMDD.bufr
 
-**the following CRTM SpcCoeff files in little_endian must be present in the working directory for CrIS radiance to brightness temperature conversion**  
+**the following CRTM SpcCoeff files in little_endian must be present in the working directory for CrIS radiance to
+brightness temperature conversion**  
 _for **cris** bufr file_  
 cris_npp.SpcCoeff.bin -> cris399_npp.SpcCoeff.bin  
 cris_n20.SpcCoeff.bin -> cris399_n20.SpcCoeff.bin  
 _for **crisf4** bufr file_  
 cris_npp.SpcCoeff.bin -> cris-fsr431_npp.SpcCoeff.bin  
-cris_n20.SpcCoeff.bin -> cris-fsr431_n20.SpcCoeff.bin  
+cris_n20.SpcCoeff.bin -> cris-fsr431_n20.SpcCoeff.bin
 
 Example output files:  
-  cris_npp_obs_YYYYMMDDHH.h5  
-  cris_n20_obs_YYYYMMDDHH.h5  
+cris_npp_obs_YYYYMMDDHH.h5  
+cris_n20_obs_YYYYMMDDHH.h5
 
 > obs2ioda-v2.x -i input_dir -o output_dir gdas.gpsro.tHHz.YYYYMMDD.bufr
 
 Example output files:  
-  gnssro_obs_YYYYMMDDHH.h5  
+gnssro_obs_YYYYMMDDHH.h5
 
 ## Converting Himawari Standard Data (HSD) FLDK files
+
 ```
 Usage: obs2ioda-v2.x -i input_dir -ahi -t YYYYMMDDHHNN [-s 1]
 ```
 
 Input files are a list of Himawari Standard Data, e.g. HS_H08_20200815_0000_B14_FLDK_R20_S0210.DAT in the input_dir.  
 Minute must be specified in the time (-t) option.  
-Number of pixels to skip must be specified in the (-s) option. The default value of 1 means no pixels will be skipped. 
+Number of pixels to skip must be specified in the (-s) option. The default value of 1 means no pixels will be skipped.
 
 ## Notes
+
 * The output prefix (before _obs) is defined in define_mod.f90
 * The mapping of numeric report types to the named types is coded in define_mod.f90
-through subroutines set_obtype_conv, set_name_satellite, set_name_sensor.
-* For gdas.satwnd.tHHz.YYYYMMDD.bufr, only GOES-16/GOES-17, AVHRR (METOP/NOAA), VIIRS (NPP/NOAA), LEOGEO AMVs are converted when available. Other AMVs are available through PREPBUFR files.
+  through subroutines set_obtype_conv, set_name_satellite, set_name_sensor.
+* For gdas.satwnd.tHHz.YYYYMMDD.bufr, only GOES-16/GOES-17, AVHRR (METOP/NOAA), VIIRS (NPP/NOAA), LEOGEO AMVs are
+  converted when available. Other AMVs are available through PREPBUFR files.
 
 ## The current version is coded to match current GSI-processed diags as close as possible.
-* The ob errors of conventional observations are either extracted from the input prepbufr or from an external error table (if obs_errtable exists in the working directory).
-* The ob errors of AMSU-A/MHS radiances are coded in define_mod.f90. This should be changed in the future to read in from an external error table.
+
+* The ob errors of conventional observations are either extracted from the input prepbufr or from an external error
+  table (if obs_errtable exists in the working directory).
+* The ob errors of AMSU-A/MHS radiances are coded in define_mod.f90. This should be changed in the future to read in
+  from an external error table.
 * The ob errors of satwnd-decoded AMVs are from an external error table (obs_errtable).
-* Subroutine filter_obs_conv applies some additional QC for conventional observations as in GSI's read_prepbufr.f90 for the global model and can be de-activated through ``-noqc`` command-line option.
-100 is added to the @PreQC value when the ob is flagged as not-use by filter_obs_conv.  
-100 is chosen to make the original prepbufr quality marker easily readable.
+* Subroutine filter_obs_conv applies some additional QC for conventional observations as in GSI's read_prepbufr.f90 for
+  the global model and can be de-activated through ``-noqc`` command-line option.
+  100 is added to the @PreQC value when the ob is flagged as not-use by filter_obs_conv.  
+  100 is chosen to make the original prepbufr quality marker easily readable.
 * Subroutine filter_obs_satwnd applies QC for GOES-16/GOES-17 AMVs as in GSI's read_satwnd.f90.  
-@PreQC value is set to 15 for rejected obs.
+  @PreQC value is set to 15 for rejected obs.
 
 

--- a/obs2ioda-v2/README.md
+++ b/obs2ioda-v2/README.md
@@ -46,7 +46,7 @@ Here are the steps to build the project:
 5. Enable unit testing (Optional) by adding:
 
    ```bash
-    export OBS2IODA_CMAKE_ARGS="${OBS2IODA_CMAKE_ARGS} -DBUILD_TESTING=ON -DPFUNIT_DIR"
+    export OBS2IODA_CMAKE_ARGS="${OBS2IODA_CMAKE_ARGS} -DBUILD_TESTS=ON -DPFUNIT_DIR"
    ```
 
 6. Configure the build with CMake:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/fortran")

--- a/tests/fortran/CMakeLists.txt
+++ b/tests/fortran/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+add_pfunit_ctest( Test_set_brit_ahi_mod
+                  TEST_SOURCES Test_set_brit_ahi_mod.pf
+                  LINK_LIBRARIES v2
+                  )
+target_include_directories(Test_set_brit_ahi_mod PRIVATE ${PFUNIT_INCLUDE_DIRS})

--- a/tests/fortran/Test_set_brit_ahi_mod.pf
+++ b/tests/fortran/Test_set_brit_ahi_mod.pf
@@ -1,0 +1,117 @@
+module Test_set_brit_ahi_mod
+    !> Test suite for the `set_brit_ahi` subroutine in `ncio_mod`.
+    !! This suite tests the correct assignment of `set_brit` and `set_ahi` flags
+    !! based on the `geo_inst` input array and the `ityp` index.
+    !!
+    !! The `set_brit_ahi` subroutine inspects the `geo_inst` array of instrument names,
+    !! setting `set_brit` to `.true.` if the instrument type (specified by `ityp`)
+    !! does not match 'ahi_himawari8', and setting `set_ahi` to `.true.` otherwise.
+    !! The subroutine also includes a bounds check to ensure that `geo_inst`
+    !! is never accessed when `ityp` exceeds the array size, preventing out-of-bounds errors.
+    !!
+    !! Tests:
+    !! - `test_set_brit_ahi_prod`: Tests `set_brit_ahi` using the `geoinst_list` array,
+    !!   ensuring the correct setting of `set_brit` and `set_ahi` for the array used in production.
+    !! - `test_set_brit_ahi1`: Checks behavior when `geo_inst` contains only 'ahi_himawari8',
+    !!   validating that `set_ahi` is set based on `ityp`.
+    !! - `test_set_brit_ahi2`: Verifies `set_brit` and `set_ahi` with an array
+    !!   containing 'ahi_himawari9' and 'ahi_himawari8'.
+    !! - `test_set_brit_ahi3`: Ensures correct flag settings for a `geo_inst` array
+    !!   containing 'ahi_himawari9', 'ahi_himawari10', and 'ahi_himawari8'.
+    !!
+    !! Each test iterates over values of `ityp`, comparing `set_brit` and `set_ahi`
+    !! against expected values for comprehensive coverage and ensures that `geo_inst`
+    !! is accessed within bounds.
+
+    use funit
+    use define_mod, only: geoinst_list
+    implicit none
+
+    @testCase
+    type, extends(TestCase) :: Test_set_brit_ahi_t
+        character(len = 256), dimension(1) :: geo_inst1 = (/"ahi_himawari8"/)
+        character(len = 256), dimension(2) :: geo_inst2 = (/"ahi_himawari9", "ahi_himawari8"/)
+        character(len = 256), dimension(3) :: geo_inst3 = (/"ahi_himawari9 ", "ahi_himawari10", "ahi_himawari8 " /)
+        logical :: set_brit, set_ahi
+
+    contains
+        procedure :: test_set_brit_ahi1
+        procedure :: test_set_brit_ahi2
+        procedure :: test_set_brit_ahi3
+    end type Test_set_brit_ahi_t
+
+contains
+    subroutine set_brit_ahi(geo_inst, ityp, set_brit, set_ahi)
+        character(len = *), dimension(:), intent(in) :: geo_inst
+        integer, intent(in) :: ityp
+        logical, intent(out) :: set_brit, set_ahi
+        set_brit = .false.
+        set_ahi = .false.
+
+        if (ityp <= size(geo_inst)) then
+            if  (geo_inst(ityp) == 'ahi_himawari8') then
+                set_ahi = .true.
+                return
+            end if
+        end if
+        set_brit = .true.
+    end subroutine set_brit_ahi
+
+    @test
+    subroutine test_set_brit_ahi_prod(this)
+        class(Test_set_brit_ahi_t), intent(inout) :: this
+        integer :: ityp
+        logical, dimension(5) :: expected_brit = [.false., .true., .true., .true., .true.]
+        logical, dimension(5) :: expected_ahi = [.true., .false., .false., .false., .false.]
+
+        do ityp = 1, 5
+            call set_brit_ahi(geoinst_list, ityp, this%set_brit, this%set_ahi)
+            call assertEqual(expected_brit(ityp), this%set_brit)
+            call assertEqual(expected_ahi(ityp), this%set_ahi)
+        end do
+    end subroutine test_set_brit_ahi_prod
+
+    @test
+    subroutine test_set_brit_ahi1(this)
+        class(Test_set_brit_ahi_t), intent(inout) :: this
+        integer :: ityp
+        logical, dimension(5) :: expected_brit = [.false., .true., .true., .true., .true.]
+        logical, dimension(5) :: expected_ahi = [.true., .false., .false., .false., .false.]
+
+        do ityp = 1, 5
+            call set_brit_ahi(this%geo_inst1, ityp, this%set_brit, this%set_ahi)
+            call assertEqual(expected_brit(ityp), this%set_brit)
+            call assertEqual(expected_ahi(ityp), this%set_ahi)
+        end do
+    end subroutine test_set_brit_ahi1
+
+    @test
+    subroutine test_set_brit_ahi2(this)
+        class(Test_set_brit_ahi_t), intent(inout) :: this
+        integer :: ityp
+        logical, dimension(5) :: expected_brit = [.true., .false., .true., .true., .true.]
+        logical, dimension(5) :: expected_ahi = [.false., .true., .false., .false., .false.]
+
+        do ityp = 1, 5
+            call set_brit_ahi(this%geo_inst2, ityp, this%set_brit, this%set_ahi)
+            call assertEqual(expected_brit(ityp), this%set_brit)
+            call assertEqual(expected_ahi(ityp), this%set_ahi)
+        end do
+    end subroutine test_set_brit_ahi2
+
+    @test
+    subroutine test_set_brit_ahi3(this)
+        class(Test_set_brit_ahi_t), intent(inout) :: this
+        integer :: ityp
+        logical, dimension(5) :: expected_brit = [.true., .true., .false., .true., .true.]
+        logical, dimension(5) :: expected_ahi = [.false., .false., .true., .false., .false.]
+
+        do ityp = 1, 5
+            call set_brit_ahi(this%geo_inst3, ityp, this%set_brit, this%set_ahi)
+            call assertEqual(expected_brit(ityp), this%set_brit)
+            call assertEqual(expected_ahi(ityp), this%set_ahi)
+        end do
+
+    end subroutine test_set_brit_ahi3
+
+end module Test_set_brit_ahi_mod


### PR DESCRIPTION
**TYPE:** enhancement

**KEYWORDS:** pfunit, testing, stability

**SOURCE:** internal

**DESCRIPTION OF CHANGES:**

**Problem:**
obs2ioda currently lacks a unit testing framework, which makes it challenging to ensure ongoing code stability as the code evolves. This gap increases the risk of unnoticed issues, such as a recent array out-of-bounds bug that went undetected for over a year. Without unit tests, developers also lack a mechanism to validate new features or bug fixes, making it difficult to enforce good software design practices.

**Solution:**
This PR integrates the pFUnit framework for Fortran unit testing, providing developers with the ability to create and run unit tests for existing and new code. An example test is included to demonstrate how pFUnit could have caught a recent array out-of-bounds error. To avoid impacting the majority of obs2ioda users, pFUnit is added as an optional dependency, required only for those building and running tests. While pFUnit installation is generally straightforward, there may be minor complications in environments with multiple versions of gptl. Clear guidance on installation is provided to mitigate these risks.

**TESTS CONDUCTED:**
- Verified that example test detects intentional errors, confirming functionality.
- Confirmed that pFUnit dependency does not interfere with normal obs2ioda usage.
- Tested pFUnit installation in various environments to ensure manageable setup.

The addition of pFUnit as a testing framework strengthens code stability and enforces testable, modular code, benefiting the obs2ioda development workflow and quality assurance.