### PR TITLE
Fix Segmentation Fault and Memory Access Issues in AHI File Parsing by Initializing iloc

### DIFF
--- a/cmake/Functions/Obs2Ioda_Functions.cmake
+++ b/cmake/Functions/Obs2Ioda_Functions.cmake
@@ -13,25 +13,15 @@ function(obs2ioda_fortran_target target target_main)
     set(OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
         $<$<COMPILE_LANGUAGE:Fortran>:-mcmodel=medium>
     )
-        if (CMAKE_Fortran_COMPILER_ID MATCHES GNU)
-                list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
-                     $<$<COMPILE_LANGUAGE:Fortran>:-cpp -ffree-line-length-none>
-                )
-                if (CMAKE_BUILD_TYPE MATCHES Debug)
-                    list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
-                         $<$<COMPILE_LANGUAGE:Fortran>:-fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=all>
-                    )
-                endif ()
-            elseif (CMAKE_Fortran_COMPILER_ID MATCHES Intel)
-                list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
-                     $<$<COMPILE_LANGUAGE:Fortran>:-fpp>
-                )
-                if (CMAKE_BUILD_TYPE MATCHES Debug)
-                    list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
-                         $<$<COMPILE_LANGUAGE:Fortran>:-check uninit -ftrapuv -g -traceback -fpe0>
-                    )
-                endif ()
-            endif ()
+    if (CMAKE_Fortran_COMPILER_ID MATCHES GNU)
+        list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
+             $<$<COMPILE_LANGUAGE:Fortran>:-cpp -ffree-line-length-none>
+        )
+    elseif (CMAKE_Fortran_COMPILER_ID MATCHES Intel)
+        list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
+             $<$<COMPILE_LANGUAGE:Fortran>:-fpp>
+        )
+    endif ()
     target_compile_options(${target} PRIVATE ${OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE})
     target_link_libraries(${target} PUBLIC ${public_link_libraries})
     add_executable(obs2ioda_${target} ${target_main})

--- a/cmake/Functions/Obs2Ioda_Functions.cmake
+++ b/cmake/Functions/Obs2Ioda_Functions.cmake
@@ -13,20 +13,25 @@ function(obs2ioda_fortran_target target target_main)
     set(OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
         $<$<COMPILE_LANGUAGE:Fortran>:-mcmodel=medium>
     )
-    if (CMAKE_Fortran_COMPILER_ID MATCHES GNU)
-        list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
-             $<$<COMPILE_LANGUAGE:Fortran>:-cpp -ffree-line-length-none>
-        )
-        if (CMAKE_BUILD_TYPE MATCHES Debug)
-            list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
-                 $<$<COMPILE_LANGUAGE:Fortran>:-fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=all>
-            )
-        endif ()
-    elseif (CMAKE_Fortran_COMPILER_ID MATCHES Intel)
-        list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
-             $<$<COMPILE_LANGUAGE:Fortran>:-fpp>
-        )
-    endif ()
+        if (CMAKE_Fortran_COMPILER_ID MATCHES GNU)
+                list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
+                     $<$<COMPILE_LANGUAGE:Fortran>:-cpp -ffree-line-length-none>
+                )
+                if (CMAKE_BUILD_TYPE MATCHES Debug)
+                    list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
+                         $<$<COMPILE_LANGUAGE:Fortran>:-fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=all>
+                    )
+                endif ()
+            elseif (CMAKE_Fortran_COMPILER_ID MATCHES Intel)
+                list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
+                     $<$<COMPILE_LANGUAGE:Fortran>:-fpp>
+                )
+                if (CMAKE_BUILD_TYPE MATCHES Debug)
+                    list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
+                         $<$<COMPILE_LANGUAGE:Fortran>:-check uninit -ftrapuv -g -traceback -fpe0>
+                    )
+                endif ()
+            endif ()
     target_compile_options(${target} PRIVATE ${OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE})
     target_link_libraries(${target} PUBLIC ${public_link_libraries})
     add_executable(obs2ioda_${target} ${target_main})

--- a/cmake/Functions/Obs2Ioda_Functions.cmake
+++ b/cmake/Functions/Obs2Ioda_Functions.cmake
@@ -17,6 +17,11 @@ function(obs2ioda_fortran_target target target_main)
         list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
              $<$<COMPILE_LANGUAGE:Fortran>:-cpp -ffree-line-length-none>
         )
+        if (CMAKE_BUILD_TYPE MATCHES Debug)
+            list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
+                 $<$<COMPILE_LANGUAGE:Fortran>:-fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=all>
+            )
+        endif ()
     elseif (CMAKE_Fortran_COMPILER_ID MATCHES Intel)
         list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
              $<$<COMPILE_LANGUAGE:Fortran>:-fpp>

--- a/obs2ioda-v2/src/hsd.f90
+++ b/obs2ioda-v2/src/hsd.f90
@@ -748,6 +748,7 @@ else
   end if
 
   ! do thinning every subsample pixels
+  iloc = 0
   do jj = 1, nline, subsample
      do ii = 1, npixel, subsample
         if ( .not. valid(ii,jj) ) cycle


### PR DESCRIPTION
**Description**

---
This PR addresses a critical issue where the iloc variable was not initialized in the read_HSD subroutine within ahi_HSD_mod. This uninitialized variable led to out-of-bounds memory access and incorrect calculations, particularly when parsing AHI files without superobbing.

**Summary of Changes**

---
Bug Fix: iloc variable initialization.
The iloc counter, which tracks the data point location during AHI file parsing, is now initialized to 0 at the start of the parsing loop. This prevents segmentation faults that were occurring due to uninitialized memory access and inaccurate data handling.
Specifically, this change ensures that the code does not attempt to access invalid memory or overwrite values in the output arrays, resulting in more accurate parsing and allocation of AHI data into the xdata structure.

**Context**
---
The issue was observed during the parsing of AHI files without superobbing, where iloc was accessed without an initial value. This fix helps maintain data integrity across the parsing process and enhances the robustness of the data handling.