### PR TITLE
Fix Out-of-Bounds Error and Streamline Logic for Setting Observation Error Subroutine in ncio_mod.f90

### DIFF
--- a/obs2ioda-v2/src/ncio_mod.f90
+++ b/obs2ioda-v2/src/ncio_mod.f90
@@ -89,7 +89,7 @@ subroutine write_obs (filedate, write_opt, outdir, itim)
          allocate (ichan(xdata(ityp,itim)%nvars))
          ichan(:) = xdata(ityp,itim)%xseninfo_int(:,iv)
          allocate (obserr(xdata(ityp,itim)%nvars))
-         if  ( geoinst_list(ityp) == 'ahi_himawari8' ) then
+         if  ( write_opt == write_nc_radiance_geo ) then
              call set_ahi_obserr(geoinst_list(ityp), xdata(ityp,itim)%nvars, obserr)
          else
              call set_brit_obserr(inst_list(ityp), xdata(ityp,itim)%nvars, obserr)


### PR DESCRIPTION

#### Problem
The original code in `ncio_mod.f90` encountered an out-of-bounds error with bounds checking enabled, primarily due to the following reasons:
1. **Out-of-Bounds Access**: The code attempted to access `geoinst_list(ityp)` where `ityp` often exceeded the bounds of `geoinst_list`, causing a runtime error when bounds checking was enabled in gfortran.
2. **Convoluted Logic**: The condition for selecting the `set_obserr` subroutine relied on checking if `geoinst_list(ityp)` equaled `"ahi_himawari8"`. However, this was indirect and unreliable, as the true condition of interest was whether `write_opt == write_nc_radiance_geo`.

#### Solution
The logic was refactored to directly check `if (write_opt == write_nc_radiance_geo)`, ensuring the proper subroutine (`set_ahi_obserr` or `set_brit_obserr`) is selected based on this condition alone. This simplifies the code and avoids the risk of accessing out-of-bounds elements in `geoinst_list`.

#### Summary of Code Changes
- Replaced `if (geoinst_list(ityp) == "ahi_himawari8")` with `if (write_opt == write_nc_radiance_geo)`.
- This new condition directly matches the intended condition for setting observation errors without risking out-of-bounds access.

#### Impact
This fix resolves the bounds error when using bounds-checking compilers like gfortran, improves code readability, and aligns the logic more closely with the intended conditions for setting observation errors.
