### PR TITLE
Split `obs2ioda_fortran_target` into `obs2ioda_fortran_library` and `obs2ioda_fortran_executable`  

### DIFF
--- a/cmake/Obs2Ioda_Functions.cmake
+++ b/cmake/Obs2Ioda_Functions.cmake
@@ -1,10 +1,10 @@
 include("${CMAKE_SOURCE_DIR}/cmake/Obs2Ioda_CompilerFlags.cmake")
 
-# This CMake function, `obs2ioda_fortran_target`, configures Fortran targets for obs2ioda.
+# This CMake function, `obs2ioda_fortran_library_target`, configures Fortran library targets for obs2ioda.
 #
 # Its arguments are:
 # - target: the name of the target to configure
-# - target_main: the main source file for the executable
+# - public_link_libraries: the public link libraries associated with the target
 #
 # The function sets the following properties for the target:
 # - The directory for Fortran module files
@@ -14,17 +14,14 @@ include("${CMAKE_SOURCE_DIR}/cmake/Obs2Ioda_CompilerFlags.cmake")
 # - Compiler-specific options and flags, depending on whether the GNU Fortran or Intel Fortran compiler is used,
 #   and whether the build type is Debug or not
 #
-# The function also links the public libraries to the target and creates an executable `obs2ioda_${target}` linked
-# to the original target.
-function(obs2ioda_fortran_target target target_main)
+# The function also links the provided public libraries to the target.
+function(obs2ioda_fortran_library target public_link_libraries)
     set_target_properties(${target} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${OBS2IODA_MODULE_DIR})
     target_include_directories(${target} INTERFACE $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${OBS2IODA_MODULE_DIR}>
                                $<INSTALL_INTERFACE:${OBS2IODA_MODULE_DIR}>)
     #Relocatable, portable, runtime dynamic linking
     set_target_properties(${target} PROPERTIES INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
     # Global Fortran configuration
-    set(public_link_libraries_name ${target}_PUBLIC_LINK_LIBRARIES)
-    set(public_link_libraries ${${public_link_libraries_name}})
     set_target_properties(${target} PROPERTIES Fortran_FORMAT FREE)
 
     # Compiler-specific options and flags
@@ -50,7 +47,20 @@ function(obs2ioda_fortran_target target target_main)
     endif ()
     target_compile_options(${target} PRIVATE ${OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE})
     target_link_libraries(${target} PUBLIC ${public_link_libraries})
-    add_executable(obs2ioda_${target} ${target_main})
-    target_link_libraries(obs2ioda_${target} PUBLIC ${target})
+endfunction()
 
+# This CMake function, `obs2ioda_fortran_executable`, configures the installation and linking of Fortran executables for obs2ioda.
+#
+# Its arguments are:
+# - target: the name of the executable target to configure
+# - public_link_libraries: the public link libraries associated with the target
+#
+# The function performs the following:
+# - Sets the install RPATH for the target to enable finding shared libraries relative to the executable's location.
+# - Links the provided public libraries to the target using `target_link_libraries`.
+#
+# This ensures that the target has the correct runtime library paths and is properly linked with its public dependencies.
+function(obs2ioda_fortran_executable target public_link_libraries)
+    set_target_properties(${target} PROPERTIES INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+    target_link_libraries(${target} PUBLIC ${public_link_libraries})
 endfunction()

--- a/obs2ioda-v2/CMakeLists.txt
+++ b/obs2ioda-v2/CMakeLists.txt
@@ -9,7 +9,6 @@ set(v2_SOURCES
     hsd.f90
     satwnd_mod.f90
     kinds.f90
-    main.f90
     ncio_mod.f90
     netcdf_mod.f90
     prepbufr_mod.f90
@@ -18,11 +17,14 @@ set(v2_SOURCES
     utils_mod.f90
 )
 list(TRANSFORM v2_SOURCES PREPEND "src/")
-set(v2_MAIN_SOURCE
+set(obs2ioda_v2_SOURCES
     main.f90
 )
-list(TRANSFORM v2_MAIN_SOURCE PREPEND "src/")
+list(TRANSFORM obs2ioda_v2_SOURCES PREPEND "src/")
 set(v2_PUBLIC_LINK_LIBRARIES "${NetCDF_LIBRARIES}" "${NCEP_BUFR_LIB}")
 add_library(v2 SHARED ${v2_SOURCES})
-obs2ioda_fortran_target(v2 ${v2_MAIN_SOURCE})
+obs2ioda_fortran_library(v2 "${v2_PUBLIC_LINK_LIBRARIES}")
+set(obs2ioda_v2_PUBLIC_LINK_LIBRARIES v2 )
+add_executable(obs2ioda_v2 ${obs2ioda_v2_SOURCES})
+obs2ioda_fortran_executable(obs2ioda_v2 "${obs2ioda_v2_PUBLIC_LINK_LIBRARIES}")
 


### PR DESCRIPTION
#### Summary  
This PR refactors the `obs2ioda_fortran_target` CMake function by splitting its functionality into two separate functions:  
- `obs2ioda_fortran_library`  
- `obs2ioda_fortran_executable`  

#### Background  
Previously, the `obs2ioda_fortran_target` function served two purposes:  
1. Configuring a Fortran library by setting target properties.  
2. Creating a corresponding executable.  

This coupling meant the function could only be used when both a Fortran library **and** a corresponding executable were required. It was not possible to configure a standalone Fortran library without also creating an executable, limiting its flexibility.

#### Changes Made  
- Introduced `obs2ioda_fortran_library` to handle the creation and configuration of standalone Fortran libraries.  
- Introduced `obs2ioda_fortran_executable` to handle the creation and configuration of Fortran executables.  
- Removed the dependency between library and executable creation, allowing greater flexibility and improved modularity in CMake configurations.

#### Benefits  
- Enables the creation of standalone Fortran libraries without requiring a corresponding executable.  
- Simplifies and clarifies the intended use of each function.  
- Improves modularity and maintainability of the build system.
