### PR TITLE
Add obs2ioda_cxx_library CMake Function for Configuring C++ Libraries

### DIFF
--- a/cmake/Obs2Ioda_Functions.cmake
+++ b/cmake/Obs2Ioda_Functions.cmake
@@ -54,3 +54,21 @@ function(obs2ioda_fortran_target target target_main)
     target_link_libraries(obs2ioda_${target} PUBLIC ${target})
 
 endfunction()
+
+# This CMake function, `obs2ioda_cxx_library`, configures C++ targets for obs2ioda.
+#
+# Its arguments are:
+# - target: the name of the C++ target to configure
+# - public_link_libraries: the public link libraries associated with the target
+#
+# The function performs the following:
+# * Sets the `INSTALL_RPATH` property for the target, ensuring that shared libraries can be found
+#    relative to the target's installation directory.
+# * Links the provided public libraries to the target using `target_link_libraries`.
+#
+# This setup ensures that the target is correctly linked with its public dependencies and that
+# runtime shared library paths are properly configured for relocatable installations.
+function(obs2ioda_cxx_library target public_link_libraries)
+    set_target_properties(${target} PROPERTIES INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+    target_link_libraries(${target} PUBLIC ${public_link_libraries})
+endfunction()


### PR DESCRIPTION

**Summary**
This PR introduces a new CMake function, obs2ioda_cxx_library, to simplify and standardize the configuration of obs2ioda C++ library targets.

**Function Overview**
The obs2ioda_cxx_library function takes a single argument, target, representing the C++ target to configure. It performs the following key actions:
* Sets the INSTALL_RPATH property to ensure that shared libraries can be found relative to the target's installation directory.
* Retrieves public link libraries by dynamically constructing the variable name ${target}_PUBLIC_LINK_LIBRARIES.
* Links the retrieved libraries to the target using target_link_libraries.
* This setup ensures proper linkage and runtime configuration for relocatable installations.

**Benefits**
* Improved Modularity: Centralizes and simplifies the configuration of C++ libraries in obs2ioda.
* Consistency: Ensures all C++ libraries follow the same setup process for linking and runtime path configuration.
* Ease of Use: Reduces repetitive CMake code by encapsulating common configuration steps in a reusable function.
