### PR TITLE
Add `netcdfErrorMessage` Function for Handling NetCDF C++ Exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 
 include("${CMAKE_SOURCE_DIR}/cmake/Obs2Ioda_Functions.cmake")
 # Define the project
-project(obs2ioda LANGUAGES Fortran)
+project(obs2ioda LANGUAGES Fortran CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -17,6 +17,6 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/${OBS2IODA_MODULE_DIR}/ DESTINATION ${CMAK
 set(NCEP_BUFR_LIB CACHE STRING "" )
 
 # Find required packages
-find_package(NetCDF REQUIRED COMPONENTS Fortran C)
+find_package(NetCDF REQUIRED COMPONENTS Fortran C CXX)
 
 add_subdirectory("${CMAKE_SOURCE_DIR}/obs2ioda-v2")

--- a/cmake/Obs2Ioda_Functions.cmake
+++ b/cmake/Obs2Ioda_Functions.cmake
@@ -82,3 +82,21 @@ function(obs2ioda_cxx_library target public_link_libraries)
     set_target_properties(${target} PROPERTIES INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
     target_link_libraries(${target} PUBLIC ${public_link_libraries})
 endfunction()
+
+# This CMake function, `obs2ioda_cxx_library`, configures C++ targets for obs2ioda.
+#
+# Its arguments are:
+# - target: the name of the C++ target to configure
+# - public_link_libraries: the public link libraries associated with the target
+#
+# The function performs the following:
+# * Sets the `INSTALL_RPATH` property for the target, ensuring that shared libraries can be found
+#    relative to the target's installation directory.
+# * Links the provided public libraries to the target using `target_link_libraries`.
+#
+# This setup ensures that the target is correctly linked with its public dependencies and that
+# runtime shared library paths are properly configured for relocatable installations.
+function(obs2ioda_cxx_library target public_link_libraries)
+    set_target_properties(${target} PROPERTIES INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+    target_link_libraries(${target} PUBLIC ${public_link_libraries})
+endfunction()

--- a/cmake/Obs2Ioda_Functions.cmake
+++ b/cmake/Obs2Ioda_Functions.cmake
@@ -69,34 +69,20 @@ endfunction()
 #
 # Its arguments are:
 # - target: the name of the C++ target to configure
+# - include_dirs: the include directories associated with the target
 # - public_link_libraries: the public link libraries associated with the target
 #
 # The function performs the following:
 # * Sets the `INSTALL_RPATH` property for the target, ensuring that shared libraries can be found
 #    relative to the target's installation directory.
 # * Links the provided public libraries to the target using `target_link_libraries`.
+# * Sets the include directories for the target using `target_include_directories`.
 #
 # This setup ensures that the target is correctly linked with its public dependencies and that
-# runtime shared library paths are properly configured for relocatable installations.
-function(obs2ioda_cxx_library target public_link_libraries)
+# runtime shared library paths are properly configured for relocatable installations, and that the target
+# can find its include directories.
+function(obs2ioda_cxx_library target include_dirs public_link_libraries)
     set_target_properties(${target} PROPERTIES INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
     target_link_libraries(${target} PUBLIC ${public_link_libraries})
-endfunction()
-
-# This CMake function, `obs2ioda_cxx_library`, configures C++ targets for obs2ioda.
-#
-# Its arguments are:
-# - target: the name of the C++ target to configure
-# - public_link_libraries: the public link libraries associated with the target
-#
-# The function performs the following:
-# * Sets the `INSTALL_RPATH` property for the target, ensuring that shared libraries can be found
-#    relative to the target's installation directory.
-# * Links the provided public libraries to the target using `target_link_libraries`.
-#
-# This setup ensures that the target is correctly linked with its public dependencies and that
-# runtime shared library paths are properly configured for relocatable installations.
-function(obs2ioda_cxx_library target public_link_libraries)
-    set_target_properties(${target} PROPERTIES INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
-    target_link_libraries(${target} PUBLIC ${public_link_libraries})
+    target_include_directories(${target} PUBLIC ${include_dirs})
 endfunction()

--- a/obs2ioda-v2/CMakeLists.txt
+++ b/obs2ioda-v2/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 # Set include directories
 include_directories(${NetCDF_INCLUDE_DIRS} )
+add_subdirectory(src/cxx)
 
 # Define sources
 set(v2_SOURCES
@@ -23,7 +24,7 @@ set(obs2ioda_v2_SOURCES
     main.f90
 )
 list(TRANSFORM obs2ioda_v2_SOURCES PREPEND "src/")
-set(v2_PUBLIC_LINK_LIBRARIES "${NetCDF_LIBRARIES}" "${NCEP_BUFR_LIB}")
+set(v2_PUBLIC_LINK_LIBRARIES "${NetCDF_LIBRARIES}" "${NCEP_BUFR_LIB}" obs2ioda_cxx)
 add_library(v2 SHARED ${v2_SOURCES})
 obs2ioda_fortran_library(v2 "${v2_PUBLIC_LINK_LIBRARIES}")
 set(obs2ioda_v2_PUBLIC_LINK_LIBRARIES v2 )

--- a/obs2ioda-v2/src/cxx/CMakeLists.txt
+++ b/obs2ioda-v2/src/cxx/CMakeLists.txt
@@ -5,5 +5,8 @@ set(obs2ioda_cxx_LIBRARIES
     NetCDF::NetCDF_CXX
     NetCDF::NetCDF_C
 )
+set(obs2ioda_cxx_INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
 add_library(obs2ioda_cxx SHARED ${obs2ioda_cxx_SOURCES})
-obs2ioda_cxx_library(obs2ioda_cxx "${obs2ioda_cxx_LIBRARIES}")
+obs2ioda_cxx_library(obs2ioda_cxx "${obs2ioda_cxx_INCLUDE_DIRS}" "${obs2ioda_cxx_LIBRARIES}")

--- a/obs2ioda-v2/src/cxx/CMakeLists.txt
+++ b/obs2ioda-v2/src/cxx/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(obs2ioda_cxx_SOURCES
+    netcdf_error.cc
+)
+set(obs2ioda_cxx_LIBRARIES
+    NetCDF::NetCDF_CXX
+    NetCDF::NetCDF_C
+)
+add_library(obs2ioda_cxx SHARED ${obs2ioda_cxx_SOURCES})
+obs2ioda_cxx_library(obs2ioda_cxx "${obs2ioda_cxx_LIBRARIES}")

--- a/obs2ioda-v2/src/cxx/netcdf_error.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_error.cc
@@ -1,14 +1,24 @@
+#include <sstream>
 #include "netcdf_error.h"
 
 namespace Obs2Ioda {
 
     int netcdfErrorMessage(
-            netCDF::exceptions::NcException &e
+            const netCDF::exceptions::NcException &e,
+            int lineNumber,
+            const std::string& fileName
     ) {
-        std::cerr
-                << "NetCDF Error: "
-                << e.what()
-                << std::endl;
+        std::stringstream message;
+        message << "NetCDF Error" << std::endl;
+        message << "Error code: " << e.errorCode() << std::endl;
+        if (not fileName.empty()) {
+            message << "Obs2Ioda File: " << fileName << std::endl;
+            if (lineNumber > 0) {
+                message << "Obs2Ioda Line: " << lineNumber << std::endl;
+            }
+        }
+        message << "Message: " << e.what() << std::endl;
+        std::cerr << message.str();
         return e.errorCode();
     }
 }

--- a/obs2ioda-v2/src/cxx/netcdf_error.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_error.cc
@@ -1,0 +1,14 @@
+#include "netcdf_error.h"
+
+namespace Obs2Ioda {
+
+    int netcdfErrorMessage(
+            netCDF::exceptions::NcException &e
+    ) {
+        std::cerr
+                << "NetCDF Error: "
+                << e.what()
+                << std::endl;
+        return e.errorCode();
+    }
+}

--- a/obs2ioda-v2/src/cxx/netcdf_error.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_error.cc
@@ -9,15 +9,14 @@ namespace Obs2Ioda {
             const std::string& fileName
     ) {
         std::stringstream message;
-        message << "NetCDF Error" << std::endl;
-        message << "Error code: " << e.errorCode() << std::endl;
+        message << "NetCDF Error: Code: " << e.errorCode();
         if (not fileName.empty()) {
-            message << "Obs2Ioda File: " << fileName << std::endl;
+            message << " File: " << fileName;
             if (lineNumber > 0) {
-                message << "Obs2Ioda Line: " << lineNumber << std::endl;
+                message << " Line: " << lineNumber;
             }
         }
-        message << "Message: " << e.what() << std::endl;
+        message << std::endl << "Message: " << e.what() << std::endl;
         std::cerr << message.str();
         return e.errorCode();
     }

--- a/obs2ioda-v2/src/cxx/netcdf_error.h
+++ b/obs2ioda-v2/src/cxx/netcdf_error.h
@@ -6,11 +6,43 @@
 
 namespace Obs2Ioda {
 
+/**
+ * @brief Logs detailed information about a NetCDF exception.
+ *
+ * This function captures and logs detailed error information from a
+ * NetCDF exception, including the error code, file name, line number,
+ * and error message. The error message is output to the standard error
+ * stream, and the NetCDF error code is returned.
+ *
+ * @param e The NetCDF exception to log, of type `netCDF::exceptions::NcException`.
+ * @param lineNumber The line number in the source file where the exception occurred.
+ *                   Defaults to -1 if not provided.
+ * @param fileName The name of the source file where the exception occurred.
+ *                 Defaults to an empty string if not provided.
+ * @return The error code from the NetCDF exception.
+ *
+ * @note If `fileName` is empty, the file name and line number are not included in the log.
+ *       If `lineNumber` is less than or equal to 0, it is ignored in the log.
+ *
+ * @example
+ * @code
+ * try {
+ *     std::vector<size_t> data = {1, 2, 3, 4, 5};
+ *     std::vector<size_t> index = {0};
+ *     auto var = file.getVar("foo");
+ *     var.putVar(index, data.data());
+ * }
+ * catch (const netCDF::exceptions::NcException &e) {
+ *     Obs2Ioda::netcdfErrorMessage(e, __LINE__, __FILE__);
+ * }
+ * @endcode
+ */
     int netcdfErrorMessage(
-            netCDF::exceptions::NcException &e
+            const netCDF::exceptions::NcException &e,
+            int lineNumber = -1,
+            const std::string& fileName = ""
     );
 
 }
-
 
 #endif //OBS2IODA_NETCDF_ERROR_H

--- a/obs2ioda-v2/src/cxx/netcdf_error.h
+++ b/obs2ioda-v2/src/cxx/netcdf_error.h
@@ -1,0 +1,16 @@
+#ifndef OBS2IODA_NETCDF_ERROR_H
+#define OBS2IODA_NETCDF_ERROR_H
+
+
+#include <netcdf>
+
+namespace Obs2Ioda {
+
+    int netcdfErrorMessage(
+            netCDF::exceptions::NcException &e
+    );
+
+}
+
+
+#endif //OBS2IODA_NETCDF_ERROR_H


### PR DESCRIPTION
Updated PR Description

Summary
This PR introduces the netcdfErrorMessage function to improve NetCDF C++ exception handling in the Obs2Ioda namespace.

Changes Made
	•	Implemented netcdfErrorMessage in netcdf_error.h and netcdf_error.cpp.
	•	The function accepts a netCDF::exceptions::NcException object, a line number, and a file name as input.
	•	It formats and prints detailed error messages, including the error code, file name, and line number (if provided), to standard error.

Benefits
	•	Provides more informative and consistent error reporting for NetCDF exceptions.
	•	Simplifies exception handling by consolidating error message construction and logging into a reusable function.
	•	Enhances debugging by including file name and line number in the error message.

Example Usage

#include "netcdf_error.h"
#include <netcdf>

int ncopen(netCDF::NcFile *&file) {
    try {
        file = new netCDF::NcFile("test.nc", netCDF::NcFile::replace);
        return 0;
    } catch (const netCDF::exceptions::NcException &e) {
        return Obs2Ioda::netcdfErrorMessage(e, __LINE__, __FILE__);
    }
}

int ncclose(netCDF::NcFile *&file) {
    try {
        file->close();
        delete file;
        return 0;
    } catch (const netCDF::exceptions::NcException &e) {
        return Obs2Ioda::netcdfErrorMessage(e, __LINE__, __FILE__);
    }
}

int main() {
    netCDF::NcFile *file = nullptr;
    int status = ncopen(file);
    if (status != 0) {
        // Handle open error
    }

    status = ncclose(file);
    if (status != 0) {
        // Handle close error
    }

    return 0;
}

Notes
	•	This update improves debugging by making it easier to trace the source of errors.
	•	Future enhancements could include configurable logging levels or integration with a logging library.