### PR TITLE
Add  Fortran Interface for NetCDF File Operations Using C++ API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 include("${CMAKE_SOURCE_DIR}/cmake/Obs2Ioda_Functions.cmake")
+enable_testing()
 # Define the project
 project(obs2ioda LANGUAGES Fortran CXX)
 

--- a/obs2ioda-v2/CMakeLists.txt
+++ b/obs2ioda-v2/CMakeLists.txt
@@ -1,33 +1,35 @@
 
 # Set include directories
-include_directories(${NetCDF_INCLUDE_DIRS} )
+include_directories(${NetCDF_INCLUDE_DIRS})
 add_subdirectory(src/cxx)
 
 # Define sources
 set(v2_SOURCES
-    define_mod.f90
-    gnssro_mod.f90
-    hsd.f90
-    satwnd_mod.f90
-    kinds.f90
-    ncio_mod.f90
-    netcdf_mod.f90
-    prepbufr_mod.f90
-    radiance_mod.f90
-    ufo_variables_mod.F90
-    utils_mod.f90
-    f_c_string_t_mod.f90
-    f_c_string_1D_t_mod.f90
+        define_mod.f90
+        gnssro_mod.f90
+        hsd.f90
+        satwnd_mod.f90
+        kinds.f90
+        ncio_mod.f90
+        netcdf_mod.f90
+        prepbufr_mod.f90
+        radiance_mod.f90
+        ufo_variables_mod.F90
+        utils_mod.f90
+        f_c_string_t_mod.f90
+        f_c_string_1D_t_mod.f90
+        netcdf_cxx_i_mod.f90
+        netcdf_cxx_mod.f90
 )
 list(TRANSFORM v2_SOURCES PREPEND "src/")
 set(obs2ioda_v2_SOURCES
-    main.f90
+        main.f90
 )
 list(TRANSFORM obs2ioda_v2_SOURCES PREPEND "src/")
 set(v2_PUBLIC_LINK_LIBRARIES "${NetCDF_LIBRARIES}" "${NCEP_BUFR_LIB}" obs2ioda_cxx)
 add_library(v2 SHARED ${v2_SOURCES})
 obs2ioda_fortran_library(v2 "${v2_PUBLIC_LINK_LIBRARIES}")
-set(obs2ioda_v2_PUBLIC_LINK_LIBRARIES v2 )
+set(obs2ioda_v2_PUBLIC_LINK_LIBRARIES v2)
 add_executable(obs2ioda_v2 ${obs2ioda_v2_SOURCES})
 obs2ioda_fortran_executable(obs2ioda_v2 "${obs2ioda_v2_PUBLIC_LINK_LIBRARIES}")
 

--- a/obs2ioda-v2/src/cxx/CMakeLists.txt
+++ b/obs2ioda-v2/src/cxx/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(obs2ioda_cxx_SOURCES
     netcdf_error.cc
+    netcdf_file.cc
 )
 set(obs2ioda_cxx_LIBRARIES
     NetCDF::NetCDF_CXX

--- a/obs2ioda-v2/src/cxx/netcdf_file.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_file.cc
@@ -3,7 +3,6 @@
 #include <memory>
 
 namespace Obs2Ioda {
-
     FileMap &FileMap::getInstance() {
         static FileMap instance;
         return instance;
@@ -56,7 +55,7 @@ namespace Obs2Ioda {
         try {
             const auto file = std::make_shared<netCDF::NcFile>(
                 path,
-                netCDF::NcFile::replace
+                static_cast<netCDF::NcFile::FileMode>(fileMode)
             );
             *netcdfID = file->getId();
             FileMap::getInstance().addFile(

--- a/obs2ioda-v2/src/cxx/netcdf_file.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_file.cc
@@ -8,7 +8,10 @@ namespace Obs2Ioda {
         return instance;
     }
 
-    int FileMap::addFile(const int netcdfID, const std::shared_ptr<netCDF::NcFile> &file) {
+    void FileMap::addFile(
+        const int netcdfID,
+        const std::shared_ptr<netCDF::NcFile> &file
+    ) {
         auto netcdfFileIterator = this->fileMap.find(netcdfID);
         if (netcdfFileIterator != this->fileMap.end()) {
             throw netCDF::exceptions::NcCantCreate(
@@ -18,11 +21,12 @@ namespace Obs2Ioda {
             );
         }
         this->fileMap[netcdfID] = file;
-        return 0;
     }
 
 
-    int FileMap::removeFile(const int netcdfID) {
+    void FileMap::removeFile(
+        const int netcdfID
+    ) {
         auto netcdfFileIterator = this->fileMap.find(netcdfID);
         if (netcdfFileIterator == this->fileMap.end()) {
             throw netCDF::exceptions::NcBadId(
@@ -32,7 +36,6 @@ namespace Obs2Ioda {
             );
         }
         this->fileMap.erase(netcdfFileIterator);
-        return 0;
     }
 
     std::shared_ptr<netCDF::NcFile> FileMap::getFile(const int netcdfID) {
@@ -76,7 +79,8 @@ namespace Obs2Ioda {
     int netcdfClose(const int netcdfID) {
         try {
             FileMap::getInstance().getFile(netcdfID)->close();
-            return FileMap::getInstance().removeFile(netcdfID);
+            FileMap::getInstance().removeFile(netcdfID);
+            return 0;
         } catch (netCDF::exceptions::NcException &e) {
             return netcdfErrorMessage(
                 e,

--- a/obs2ioda-v2/src/cxx/netcdf_file.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_file.cc
@@ -50,7 +50,8 @@ namespace Obs2Ioda {
 
     int netcdfCreate(
         const char *path,
-        int *netcdfID
+        int *netcdfID,
+        int fileMode
     ) {
         try {
             const auto file = std::make_shared<netCDF::NcFile>(

--- a/obs2ioda-v2/src/cxx/netcdf_file.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_file.cc
@@ -1,0 +1,88 @@
+#include "netcdf_file.h"
+#include "netcdf_error.h"
+#include <memory>
+
+namespace Obs2Ioda {
+
+    FileMap &FileMap::getInstance() {
+        static FileMap instance;
+        return instance;
+    }
+
+    int FileMap::addFile(const int netcdfID, const std::shared_ptr<netCDF::NcFile> &file) {
+        auto netcdfFileIterator = this->fileMap.find(netcdfID);
+        if (netcdfFileIterator != this->fileMap.end()) {
+            throw netCDF::exceptions::NcCantCreate(
+                "NetCDF ID already exists in the NetCDF file map",
+                __FILE__,
+                __LINE__
+            );
+        }
+        this->fileMap[netcdfID] = file;
+        return 0;
+    }
+
+
+    int FileMap::removeFile(const int netcdfID) {
+        auto netcdfFileIterator = this->fileMap.find(netcdfID);
+        if (netcdfFileIterator == this->fileMap.end()) {
+            throw netCDF::exceptions::NcBadId(
+                "NetCDF ID not found in the NetCDF file map",
+                __FILE__,
+                __LINE__
+            );
+        }
+        this->fileMap.erase(netcdfFileIterator);
+        return 0;
+    }
+
+    std::shared_ptr<netCDF::NcFile> FileMap::getFile(const int netcdfID) {
+        const auto netcdfFileIterator = this->fileMap.find(netcdfID);
+        if (netcdfFileIterator == this->fileMap.end()) {
+            throw netCDF::exceptions::NcBadId(
+                "NetCDF ID not found in the NetCDF file map",
+                __FILE__,
+                __LINE__
+            );
+        }
+        return netcdfFileIterator->second;
+    }
+
+    int netcdfCreate(
+        const char *path,
+        int *netcdfID
+    ) {
+        try {
+            const auto file = std::make_shared<netCDF::NcFile>(
+                path,
+                netCDF::NcFile::replace
+            );
+            *netcdfID = file->getId();
+            FileMap::getInstance().addFile(
+                *netcdfID,
+                file
+            );
+
+            return 0;
+        } catch (netCDF::exceptions::NcException &e) {
+            return netcdfErrorMessage(
+                e,
+                __LINE__,
+                __FILE__
+            );
+        }
+    }
+
+    int netcdfClose(const int netcdfID) {
+        try {
+            FileMap::getInstance().getFile(netcdfID)->close();
+            return FileMap::getInstance().removeFile(netcdfID);
+        } catch (netCDF::exceptions::NcException &e) {
+            return netcdfErrorMessage(
+                e,
+                __LINE__,
+                __FILE__
+            );
+        }
+    }
+}

--- a/obs2ioda-v2/src/cxx/netcdf_file.h
+++ b/obs2ioda-v2/src/cxx/netcdf_file.h
@@ -1,0 +1,112 @@
+#ifndef OBS2IODA_NETCDF_FILE_H
+#define OBS2IODA_NETCDF_FILE_H
+
+#include <netcdf>
+#include <unordered_map>
+#include <memory>
+
+namespace Obs2Ioda {
+/**
+ * @class FileMap
+ * @brief Singleton class for managing a mapping of NetCDF file IDs to file objects.
+ */
+class FileMap {
+public:
+    /**
+     * @brief Retrieves the singleton instance of the NetcdfFileMap.
+     *
+     * Ensures there is only one instance of the NetcdfFileMap throughout the application.
+     *
+     * @return A reference to the singleton instance of NetcdfFileMap.
+     */
+    static FileMap& getInstance();
+
+    /**
+     * @brief Deleted copy constructor to enforce singleton behavior.
+     */
+    FileMap(const FileMap&) = delete;
+
+    /**
+     * @brief Deleted assignment operator to enforce singleton behavior.
+     */
+    FileMap& operator=(const FileMap&) = delete;
+
+    /**
+     * @brief Adds a NetCDF file to the map.
+     *
+     * Associates a unique NetCDF file ID with a `std::shared_ptr` to a `netCDF::NcFile` object.
+     * Throws an exception if the ID already exists in the map.
+     *
+     * @param netcdfID The unique NetCDF file ID.
+     * @param file A shared pointer to the NetCDF file to be added.
+     * @return 0 on success, or an error code if an exception is caught.
+     * @throws netCDF::exceptions::NcCantCreate if the `netcdfID` already exists in the map.
+     */
+    int addFile(int netcdfID, const std::shared_ptr<netCDF::NcFile>& file);
+
+    /**
+     * @brief Removes a NetCDF file from the map.
+     *
+     * Removes the association of the given NetCDF file ID from the map.
+     * Throws an exception if the ID does not exist in the map.
+     *
+     * @param netcdfID The unique NetCDF file ID to be removed.
+     * @return 0 on success, or an error code if an exception is caught.
+     * @throws netCDF::exceptions::NcBadId if the `netcdfID` does not exist in the map.
+     */
+    int removeFile(int netcdfID);
+
+    /**
+     * @brief Retrieves a NetCDF file from the map.
+     *
+     * Retrieves the `std::shared_ptr` to the `netCDF::NcFile` object associated with the given
+     * NetCDF file ID.
+     *
+     * @param netcdfID The unique NetCDF file ID to retrieve.
+     * @return A shared pointer to the NetCDF file.
+     * @throws netCDF::exceptions::NcBadId if the `netcdfID` does not exist in the map.
+     */
+    std::shared_ptr<netCDF::NcFile> getFile(int netcdfID);
+
+private:
+    /**
+     * @brief Private constructor to prevent direct instantiation.
+     */
+    FileMap() = default;
+
+    /// Map associating NetCDF file IDs with their corresponding shared pointers to NetCDF files.
+    std::unordered_map<int, std::shared_ptr<netCDF::NcFile>> fileMap;
+};
+
+
+    extern "C" {
+    /**
+     * @brief Creates and opens a NetCDF file.
+     *
+     * This function creates and opens a new NetCDF file at the specified path.
+     * It stores the NetCDF file object in a map for future reference.
+     *
+     * @param path The path to the NetCDF file to be created.
+     * @param netcdfID Output parameter that will receive the ID of the created NetCDF file.
+     *
+     * @return 0 on success, or a non-zero error code on failure.
+     */
+    int netcdfCreate(
+        const char *path, ///< The path to the NetCDF file to be created.
+        int *netcdfID ///< The ID of the created NetCDF file.
+    );
+
+    /**
+     * @brief Closes the NetCDF file associated with the given ID.
+     *
+     * This function closes the NetCDF file and removes it from the internal map.
+     *
+     * @param netcdfID The ID of the NetCDF file to close.
+     *
+     * @return 0 on success, or a non-zero error code on failure.
+     */
+    int netcdfClose(int netcdfID); ///< The ID of the NetCDF file to be closed.
+    }
+} // namespace Obs2Ioda
+
+#endif // OBS2IODA_NETCDF_FILE_H

--- a/obs2ioda-v2/src/cxx/netcdf_file.h
+++ b/obs2ioda-v2/src/cxx/netcdf_file.h
@@ -43,7 +43,6 @@ namespace Obs2Ioda {
          *
          * @param netcdfID The unique NetCDF file ID.
          * @param file A shared pointer to the NetCDF file to be added.
-         * @return 0 on success, or an error code if an exception is caught.
          * @throws netCDF::exceptions::NcCantCreate if the `netcdfID` already exists in the map.
          */
         void addFile(
@@ -58,7 +57,6 @@ namespace Obs2Ioda {
          * Throws an exception if the ID does not exist in the map.
          *
          * @param netcdfID The unique NetCDF file ID to be removed.
-         * @return 0 on success, or an error code if an exception is caught.
          * @throws netCDF::exceptions::NcBadId if the `netcdfID` does not exist in the map.
          */
         void removeFile(

--- a/obs2ioda-v2/src/cxx/netcdf_file.h
+++ b/obs2ioda-v2/src/cxx/netcdf_file.h
@@ -6,77 +6,89 @@
 #include <memory>
 
 namespace Obs2Ioda {
-/**
- * @class FileMap
- * @brief Singleton class for managing a mapping of NetCDF file IDs to file objects.
- */
-class FileMap {
-public:
     /**
-     * @brief Retrieves the singleton instance of the NetcdfFileMap.
-     *
-     * Ensures there is only one instance of the NetcdfFileMap throughout the application.
-     *
-     * @return A reference to the singleton instance of NetcdfFileMap.
+     * @class FileMap
+     * @brief Singleton class for managing a mapping of NetCDF file IDs to file objects.
      */
-    static FileMap& getInstance();
+    class FileMap {
+    public:
+        /**
+         * @brief Retrieves the singleton instance of the NetcdfFileMap.
+         *
+         * Ensures there is only one instance of the NetcdfFileMap throughout the application.
+         *
+         * @return A reference to the singleton instance of NetcdfFileMap.
+         */
+        static FileMap &getInstance();
 
-    /**
-     * @brief Deleted copy constructor to enforce singleton behavior.
-     */
-    FileMap(const FileMap&) = delete;
+        /**
+         * @brief Deleted copy constructor to enforce singleton behavior.
+         */
+        FileMap(
+            const FileMap &
+        ) = delete;
 
-    /**
-     * @brief Deleted assignment operator to enforce singleton behavior.
-     */
-    FileMap& operator=(const FileMap&) = delete;
+        /**
+         * @brief Deleted assignment operator to enforce singleton behavior.
+         */
+        FileMap &operator=(
+            const FileMap &
+        ) = delete;
 
-    /**
-     * @brief Adds a NetCDF file to the map.
-     *
-     * Associates a unique NetCDF file ID with a `std::shared_ptr` to a `netCDF::NcFile` object.
-     * Throws an exception if the ID already exists in the map.
-     *
-     * @param netcdfID The unique NetCDF file ID.
-     * @param file A shared pointer to the NetCDF file to be added.
-     * @return 0 on success, or an error code if an exception is caught.
-     * @throws netCDF::exceptions::NcCantCreate if the `netcdfID` already exists in the map.
-     */
-    int addFile(int netcdfID, const std::shared_ptr<netCDF::NcFile>& file);
+        /**
+         * @brief Adds a NetCDF file to the map.
+         *
+         * Associates a unique NetCDF file ID with a `std::shared_ptr` to a `netCDF::NcFile` object.
+         * Throws an exception if the ID already exists in the map.
+         *
+         * @param netcdfID The unique NetCDF file ID.
+         * @param file A shared pointer to the NetCDF file to be added.
+         * @return 0 on success, or an error code if an exception is caught.
+         * @throws netCDF::exceptions::NcCantCreate if the `netcdfID` already exists in the map.
+         */
+        int addFile(
+            int netcdfID,
+            const std::shared_ptr<netCDF::NcFile> &file
+        );
 
-    /**
-     * @brief Removes a NetCDF file from the map.
-     *
-     * Removes the association of the given NetCDF file ID from the map.
-     * Throws an exception if the ID does not exist in the map.
-     *
-     * @param netcdfID The unique NetCDF file ID to be removed.
-     * @return 0 on success, or an error code if an exception is caught.
-     * @throws netCDF::exceptions::NcBadId if the `netcdfID` does not exist in the map.
-     */
-    int removeFile(int netcdfID);
+        /**
+         * @brief Removes a NetCDF file from the map.
+         *
+         * Removes the association of the given NetCDF file ID from the map.
+         * Throws an exception if the ID does not exist in the map.
+         *
+         * @param netcdfID The unique NetCDF file ID to be removed.
+         * @return 0 on success, or an error code if an exception is caught.
+         * @throws netCDF::exceptions::NcBadId if the `netcdfID` does not exist in the map.
+         */
+        int removeFile(
+            int netcdfID
+        );
 
-    /**
-     * @brief Retrieves a NetCDF file from the map.
-     *
-     * Retrieves the `std::shared_ptr` to the `netCDF::NcFile` object associated with the given
-     * NetCDF file ID.
-     *
-     * @param netcdfID The unique NetCDF file ID to retrieve.
-     * @return A shared pointer to the NetCDF file.
-     * @throws netCDF::exceptions::NcBadId if the `netcdfID` does not exist in the map.
-     */
-    std::shared_ptr<netCDF::NcFile> getFile(int netcdfID);
+        /**
+         * @brief Retrieves a NetCDF file from the map.
+         *
+         * Retrieves the `std::shared_ptr` to the `netCDF::NcFile` object associated with the given
+         * NetCDF file ID.
+         *
+         * @param netcdfID The unique NetCDF file ID to retrieve.
+         * @return A shared pointer to the NetCDF file.
+         * @throws netCDF::exceptions::NcBadId if the `netcdfID` does not exist in the map.
+         */
+        std::shared_ptr<netCDF::NcFile> getFile(
+            int netcdfID
+        );
 
-private:
-    /**
-     * @brief Private constructor to prevent direct instantiation.
-     */
-    FileMap() = default;
+    private:
+        /**
+         * @brief Private constructor to prevent direct instantiation.
+         */
+        FileMap() = default;
 
-    /// Map associating NetCDF file IDs with their corresponding shared pointers to NetCDF files.
-    std::unordered_map<int, std::shared_ptr<netCDF::NcFile>> fileMap;
-};
+        /// Map associating NetCDF file IDs with their corresponding shared pointers to NetCDF files.
+        std::unordered_map<int, std::shared_ptr<netCDF::NcFile> >
+        fileMap;
+    };
 
 
     extern "C" {
@@ -88,12 +100,20 @@ private:
      *
      * @param path The path to the NetCDF file to be created.
      * @param netcdfID Output parameter that will receive the ID of the created NetCDF file.
+     * @param fileMode The mode for creating the NetCDF file:
+     *     - 0: Open an existing file in read-only mode.
+     *     - 1: Open an existing file for writing.
+     *     - 2: Create a new file, overwriting any existing file.
+     *     - 3: Create a new file, failing if it already exists.
      *
      * @return 0 on success, or a non-zero error code on failure.
      */
     int netcdfCreate(
-        const char *path, ///< The path to the NetCDF file to be created.
-        int *netcdfID ///< The ID of the created NetCDF file.
+        const char *path,
+        ///< The path to the NetCDF file to be created.
+        int *netcdfID,
+        ///< The ID of the created NetCDF file.
+        int fileMode ///< File mode for creating the NetCDF file.
     );
 
     /**
@@ -105,7 +125,9 @@ private:
      *
      * @return 0 on success, or a non-zero error code on failure.
      */
-    int netcdfClose(int netcdfID); ///< The ID of the NetCDF file to be closed.
+    int netcdfClose(
+        int netcdfID
+    ); ///< The ID of the NetCDF file to be closed.
     }
 } // namespace Obs2Ioda
 

--- a/obs2ioda-v2/src/cxx/netcdf_file.h
+++ b/obs2ioda-v2/src/cxx/netcdf_file.h
@@ -46,7 +46,7 @@ namespace Obs2Ioda {
          * @return 0 on success, or an error code if an exception is caught.
          * @throws netCDF::exceptions::NcCantCreate if the `netcdfID` already exists in the map.
          */
-        int addFile(
+        void addFile(
             int netcdfID,
             const std::shared_ptr<netCDF::NcFile> &file
         );
@@ -61,7 +61,7 @@ namespace Obs2Ioda {
          * @return 0 on success, or an error code if an exception is caught.
          * @throws netCDF::exceptions::NcBadId if the `netcdfID` does not exist in the map.
          */
-        int removeFile(
+        void removeFile(
             int netcdfID
         );
 

--- a/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
@@ -14,6 +14,7 @@ module netcdf_cxx_i_mod
         !       string representing the file path.
         !     - netcdfID (integer(c_int), intent(out)): Receives the file identifier
         !       for the created or opened NetCDF file.
+        !     - fileMode (integer(c_int), intent(in)): File mode for creating the NetCDF file.
         !
         !   Returns:
         !     - integer(c_int): A status code indicating success (0) or failure (non-zero).
@@ -23,6 +24,7 @@ module netcdf_cxx_i_mod
             import :: c_ptr
             type(c_ptr), value, intent(in) :: path
             integer(c_int), intent(out) :: netcdfID
+            integer(c_int), intent(in) :: fileMode
             integer(c_int) :: c_netcdfCreate
         end function
 

--- a/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
@@ -18,13 +18,13 @@ module netcdf_cxx_i_mod
         !
         !   Returns:
         !     - integer(c_int): A status code indicating success (0) or failure (non-zero).
-        function c_netcdfCreate(path, netcdfID) &
+        function c_netcdfCreate(path, netcdfID, fileMode) &
                 bind(C, name = "netcdfCreate")
             import :: c_int
             import :: c_ptr
             type(c_ptr), value, intent(in) :: path
-            integer(c_int), intent(out) :: netcdfID
-            integer(c_int), intent(in) :: fileMode
+            integer(c_int), intent(inout) :: netcdfID
+            integer(c_int), value, intent(in) :: fileMode
             integer(c_int) :: c_netcdfCreate
         end function
 

--- a/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
@@ -1,0 +1,46 @@
+module netcdf_cxx_i_mod
+    use iso_c_binding, only : c_int, c_ptr
+    implicit none
+    public
+
+    interface
+        ! c_netcdfCreate:
+        !   Creates a new NetCDF file or opens an existing file in a specified mode.
+        !   The file path must be passed as a C-compatible null-terminated string.
+        !   The resulting file identifier is returned in `netcdfID` for further operations.
+        !
+        !   Arguments:
+        !     - path (type(c_ptr), intent(in), value): A C pointer to a null-terminated
+        !       string representing the file path.
+        !     - netcdfID (integer(c_int), intent(out)): Receives the file identifier
+        !       for the created or opened NetCDF file.
+        !
+        !   Returns:
+        !     - integer(c_int): A status code indicating success (0) or failure (non-zero).
+        function c_netcdfCreate(path, netcdfID) &
+                bind(C, name = "netcdfCreate")
+            import :: c_int
+            import :: c_ptr
+            type(c_ptr), value, intent(in) :: path
+            integer(c_int), intent(out) :: netcdfID
+            integer(c_int) :: c_netcdfCreate
+        end function
+
+        ! c_netcdfClose:
+        !   Closes a previously opened NetCDF file identified by its file identifier.
+        !
+        !   Arguments:
+        !     - netcdfID (integer(c_int), intent(in), value): The identifier of the
+        !       NetCDF file to close.
+        !
+        !   Returns:
+        !     - integer(c_int): A status code indicating success (0) or failure (non-zero).
+        function c_netcdfClose(netcdfID) &
+                bind(C, name = "netcdfClose")
+            import :: c_int
+            integer(c_int), value, intent(in) :: netcdfID
+            integer(c_int) :: c_netcdfClose
+        end function
+    end interface
+
+end module netcdf_cxx_i_mod

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -1,0 +1,64 @@
+module netcdf_cxx_mod
+    use iso_c_binding, only : c_int, c_ptr
+    use f_c_string_t_mod, only : f_c_string_t
+    use netcdf_cxx_i_mod, only : c_netcdfCreate, c_netcdfClose
+    use netcdf, only : NF90_INT, NF90_REAL
+    implicit none
+    public
+
+contains
+
+    ! netcdfCreate:
+    !   Creates a new NetCDF file or opens an existing file in a specified mode,
+    !   using a Fortran string for the file path. This function wraps the
+    !   `c_netcdfCreate` interface, which calls a C++ wrapper function that
+    !   interacts with the NetCDF C++ API.
+    !
+    !   Arguments:
+    !     - path (character(len=*), intent(in)): The file path as a Fortran string.
+    !     - netcdfID (integer(c_int), intent(inout)): On input, it may contain an
+    !       identifier to be updated; on output, it holds the file identifier
+    !       for the created or opened NetCDF file.
+    !
+    !   Returns:
+    !     - integer(c_int): A status code indicating success (0) or failure (non-zero).
+    !
+    !   Notes:
+    !     - The `f_c_string_t` type is used internally to handle the conversion
+    !       of the Fortran string `path` into a null-terminated C string (`c_path`).
+    !     - The `c_netcdfCreate` function serves as an interface between Fortran
+    !       and the C++ wrapper function, ensuring proper communication between
+    !       the languages.
+    function netcdfCreate(path, netcdfID)
+        character(len = *), intent(in) :: path
+        integer(c_int), intent(inout) :: netcdfID
+        integer(c_int) :: netcdfCreate
+        type(f_c_string_t) :: f_c_string_path
+        type(c_ptr) :: c_path
+
+        c_path = f_c_string_path%to_c(path)
+        netcdfCreate = c_netcdfCreate(c_path, netcdfID)
+    end function netcdfCreate
+
+    ! netcdfClose:
+    !   Closes a previously opened NetCDF file identified by its file identifier.
+    !   This function wraps the `c_netcdfClose` interface, which calls a C++
+    !   wrapper function to interact with the NetCDF C++ API.
+    !
+    !   Arguments:
+    !     - netcdfID (integer(c_int), intent(in), value): The identifier of the
+    !       NetCDF file to close.
+    !
+    !   Returns:
+    !     - integer(c_int): A status code indicating success (0) or failure (non-zero).
+    !
+    !   Notes:
+    !     - The `c_netcdfClose` function acts as an interface between Fortran and
+    !       the C++ wrapper function, abstracting the complexity of C++ interactions.
+    function netcdfClose(netcdfID)
+        integer(c_int), value, intent(in) :: netcdfID
+        integer(c_int) :: netcdfClose
+        netcdfClose = c_netcdfClose(netcdfID)
+    end function netcdfClose
+
+end module netcdf_cxx_mod

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -10,9 +10,7 @@ contains
 
     ! netcdfCreate:
     !   Creates a new NetCDF file or opens an existing file in a specified mode,
-    !   using a Fortran string for the file path. This function wraps the
-    !   `c_netcdfCreate` interface, which calls a C++ wrapper function that
-    !   interacts with the NetCDF C++ API.
+    !   using a Fortran string for the file path.
     !
     !   Arguments:
     !     - path (character(len=*), intent(in)): The file path as a Fortran string.
@@ -29,13 +27,6 @@ contains
     !
     !   Returns:
     !     - integer(c_int): A status code indicating success (0) or failure (non-zero).
-    !
-    !   Notes:
-    !     - The `f_c_string_t` type is used internally to handle the conversion
-    !       of the Fortran string `path` into a null-terminated C string (`c_path`).
-    !     - The `c_netcdfCreate` function serves as an interface between Fortran
-    !       and the C++ wrapper function, ensuring proper communication between
-    !       the languages.
     function netcdfCreate(path, netcdfID, fileMode)
         character(len = *), intent(in) :: path
         integer(c_int), intent(inout) :: netcdfID
@@ -56,8 +47,6 @@ contains
 
     ! netcdfClose:
     !   Closes a previously opened NetCDF file identified by its file identifier.
-    !   This function wraps the `c_netcdfClose` interface, which calls a C++
-    !   wrapper function to interact with the NetCDF C++ API.
     !
     !   Arguments:
     !     - netcdfID (integer(c_int), intent(in), value): The identifier of the
@@ -65,10 +54,6 @@ contains
     !
     !   Returns:
     !     - integer(c_int): A status code indicating success (0) or failure (non-zero).
-    !
-    !   Notes:
-    !     - The `c_netcdfClose` function acts as an interface between Fortran and
-    !       the C++ wrapper function, abstracting the complexity of C++ interactions.
     function netcdfClose(netcdfID)
         integer(c_int), value, intent(in) :: netcdfID
         integer(c_int) :: netcdfClose

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -19,6 +19,13 @@ contains
     !     - netcdfID (integer(c_int), intent(inout)): On input, it may contain an
     !       identifier to be updated; on output, it holds the file identifier
     !       for the created or opened NetCDF file.
+    !     - fileMode (integer(c_int), intent(in), optional):
+    !         File mode for creating or opening the NetCDF file. Defaults to 2
+    !         (replace mode). Possible values are:
+    !           - 0: Open an existing file in read-only mode.
+    !           - 1: Open an existing file for writing.
+    !           - 2: Create a new file, overwriting any existing file.
+    !           - 3: Create a new file, failing if the file already exists.
     !
     !   Returns:
     !     - integer(c_int): A status code indicating success (0) or failure (non-zero).
@@ -29,15 +36,22 @@ contains
     !     - The `c_netcdfCreate` function serves as an interface between Fortran
     !       and the C++ wrapper function, ensuring proper communication between
     !       the languages.
-    function netcdfCreate(path, netcdfID)
+    function netcdfCreate(path, netcdfID, fileMode)
         character(len = *), intent(in) :: path
         integer(c_int), intent(inout) :: netcdfID
+        integer(c_int), intent(in), optional :: fileMode
         integer(c_int) :: netcdfCreate
         type(f_c_string_t) :: f_c_string_path
         type(c_ptr) :: c_path
-
+        integer(c_int) :: mode
+        ! Set the mode to the provided fileMode if present, otherwise default to 2
+        if (present(fileMode)) then
+            mode = fileMode
+        else
+            mode = 2
+        end if
         c_path = f_c_string_path%to_c(path)
-        netcdfCreate = c_netcdfCreate(c_path, netcdfID)
+        netcdfCreate = c_netcdfCreate(c_path, netcdfID, mode)
     end function netcdfCreate
 
     ! netcdfClose:


### PR DESCRIPTION
**Description:**

- This PR introduces a Fortran interface for creating and closing NetCDF files using the NetCDF C++ API. The new implementation emphasizes thread safety, robust error handling, and user-friendly interactions. Below are the key highlights:

- Thread-Safe Operations: All file operations are implemented in a thread-safe manner. It should be noted that NetCDF itself is not guarenteed to be thread safe.

- Robust Error Handling: Utilizes the rich NetCDF C++ Exception class to handle errors gracefully and provide detailed diagnostic information when issues occur.

**User-Friendly Fortran Interface:**

- Abstracts away the complexities of Fortran/C type casting.
- Handles all memory management and memory transfers, allowing users to focus on their core logic without worrying about low-level implementation details.

**Motivation:**
The integration of the NetCDF C++ API enhances functionality and simplifies error handling compared to existing solutions. The Fortran interface ensures compatibility for existing workflows while leveraging the strengths of modern C++.

**Next Steps**:
Extend the interface to support additional NetCDF features:
Adding and retrieving groups, attributes, and variables.
Streamlining access to complex NetCDF structures.
