### PR TITLE
Add Fortran Support for Creating Dimensions in NetCDF Files Using C++ API

### DIFF
--- a/obs2ioda-v2/src/cxx/CMakeLists.txt
+++ b/obs2ioda-v2/src/cxx/CMakeLists.txt
@@ -2,6 +2,7 @@ set(obs2ioda_cxx_SOURCES
     netcdf_error.cc
     netcdf_file.cc
     netcdf_group.cc
+    netcdf_dimension.cc
 )
 set(obs2ioda_cxx_LIBRARIES
     NetCDF::NetCDF_CXX

--- a/obs2ioda-v2/src/cxx/netcdf_dimension.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_dimension.cc
@@ -1,0 +1,30 @@
+#include "netcdf_dimension.h"
+#include "netcdf_file.h"
+#include "netcdf_error.h"
+
+namespace Obs2Ioda {
+    int netcdfAddDim(
+        const int netcdfID,
+        const char *groupName,
+        const char *dimName,
+        const int len
+    ) {
+        try {
+            const auto file = FileMap::getInstance().getFile(netcdfID);
+            const auto group = !groupName
+                                   ? file
+                                   : std::make_shared<
+                                       netCDF::NcGroup>(
+                                       file->getGroup(
+                                           groupName));
+            auto dim = group->addDim(dimName, len);
+            return 0;
+        } catch (netCDF::exceptions::NcException &e) {
+            return netcdfErrorMessage(
+                e,
+                __LINE__,
+                __FILE__
+            );
+        }
+    }
+}

--- a/obs2ioda-v2/src/cxx/netcdf_dimension.h
+++ b/obs2ioda-v2/src/cxx/netcdf_dimension.h
@@ -1,0 +1,38 @@
+#ifndef NETCDF_DIMENSION_H
+#define NETCDF_DIMENSION_H
+
+
+namespace Obs2Ioda {
+    extern "C" {
+    /**
+* @brief Adds a new dimension to a NetCDF file.
+*
+* This function adds a dimension to a NetCDF file, supporting both global dimensions
+* and dimensions within a specific group.
+*
+* @param netcdfID
+*     The unique identifier for the NetCDF file. This ID is used to retrieve the
+*     corresponding file object from the internal file map.
+* @param groupName
+*     A null-terminated string specifying the name of the group in which the dimension
+*     will be created. If `NULL`, the dimension will be added to the root group.
+* @param dimName
+*     A null-terminated string specifying the name of the new dimension. The name must
+*     be unique within the target group.
+* @param len
+*     The length of the dimension.
+*
+* @return
+*     - 0 on success.
+*     - A non-zero error code if an exception is encountered.
+*/
+    int netcdfAddDim(
+        int netcdfID,
+        const char *groupName,
+        const char *dimName,
+        int len
+    );
+    }
+}
+
+#endif //NETCDF_DIMENSION_H

--- a/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
@@ -78,6 +78,40 @@ module netcdf_cxx_i_mod
             integer(c_int) :: c_netcdfAddGroup
         end function c_netcdfAddGroup
 
+        ! c_netcdfAddDim:
+        !   Adds a new dimension to a NetCDF file
+        !
+        !   Arguments:
+        !     - netcdfID (integer(c_int), intent(in), value):
+        !       The identifier of the NetCDF file to which the dimension will be added.
+        !     - groupName (type(c_ptr), intent(in), value):
+        !       A C pointer to a null-terminated string specifying the name of the group
+        !       where the dimension will be created. If creating a global dimension, pass `c_null_ptr`.
+        !     - dimName (type(c_ptr), intent(in), value):
+        !       A C pointer to a null-terminated string specifying the name of the new dimension.
+        !     - len (integer(c_int), intent(in), value):
+        !
+        !   Returns:
+        !     - integer(c_int): Status code indicating the result of the operation:
+        !         - 0: Success.
+        !         - Non-zero: Failure.
+        !
+        !   Notes:
+        !     - The function assumes that `netcdfID` is valid and corresponds to an open NetCDF file.
+        !     - `dimName` must be valid C pointers pointing to null-terminated strings.
+        !   ```
+        function c_netcdfAddDim(&
+                netcdfID, groupName, dimName, len) &
+                bind(C, name = "netcdfAddDim")
+            import :: c_int
+            import :: c_ptr
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: groupName
+            type(c_ptr), value, intent(in) :: dimName
+            integer(c_int), value, intent(in) :: len
+            integer(c_int) :: c_netcdfAddDim
+        end function c_netcdfAddDim
+
     end interface
 
 end module netcdf_cxx_i_mod

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -96,4 +96,43 @@ contains
         netcdfAddGroup = c_netcdfAddGroup(netcdfID, c_parentGroupName, c_groupName)
     end function netcdfAddGroup
 
+    ! netcdfAddDim:
+    !   Adds a new dimension to a NetCDF file, either in a specified group or as a global dimension.
+    !
+    ! Arguments:
+    !   - netcdfID (integer(c_int), intent(in), value):
+    !       Identifier of the NetCDF file.
+    !   - dimName (character(len=*), intent(in)):
+    !       Name of the new dimension.
+    !   - len (integer(c_int), intent(in), value):
+    !       Length of the dimension.
+    !   - groupName (character(len=*), intent(in), optional):
+    !       Name of the target group. If absent, the dimension is added as a global dimension.
+    !
+    ! Returns:
+    !    - integer(c_int): A status code indicating the outcome of the operation:
+    !       - 0: Success.
+    !       - Non-zero: Failure
+    function netcdfAddDim(netcdfID, dimName, len, groupName)
+        integer(c_int), value, intent(in) :: netcdfID
+        character(len = *), intent(in) :: dimName
+        integer(c_int), value, intent(in) :: len
+        character(len = *), optional, intent(in) :: groupName
+        integer(c_int) :: netcdfAddDim
+        type(c_ptr) :: c_groupName
+        type(c_ptr) :: c_dimName
+        type(f_c_string_t) :: f_c_string_groupName
+        type(f_c_string_t) :: f_c_string_dimName
+
+        if (present(groupName)) then
+            c_groupName = f_c_string_groupName%to_c(groupName)
+        else
+            c_groupName = c_null_ptr
+        end if
+        c_dimName = f_c_string_dimName%to_c(dimName)
+
+        netcdfAddDim = c_netcdfAddDim(netcdfID, c_groupName, c_dimName, len)
+
+    end function netcdfAddDim
+
 end module netcdf_cxx_mod


### PR DESCRIPTION
### **Description**:

This PR introduces support for adding dimensions to NetCDF files from Fortran using the NetCDF C++ API. The new implementation provides a Fortran interface that simplifies the process of creating dimensions, including global dimensions and group-specific dimensions, by handling all necessary memory management and C/Fortran string conversions.

### **Key Features**:
- **Dimension Creation**:
  - Supports creating dimensions in the root group or any specified group.

- **User-Friendly Fortran Interface**:
  - Abstracts low-level details by wrapping the C++ API with a Fortran-friendly interface.
  - Automatically converts Fortran strings to C-compatible null-terminated strings.
  - Handles optional arguments for specifying the target group.

### **Motivation**:
This enhancement allows Fortran users to leverage the powerful capabilities of the NetCDF C++ API without needing to manage low-level details like memory allocation, string conversions, or threading concerns. It extends the flexibility and usability of the Fortran interface for NetCDF file operations.

### **Next Steps**:
- Extend the interface to support additional operations:
  - Adding and managing variables and attributes.
  - Enhanced error reporting for dimension-related operations.
