### PR TITLE
Fix satellite ID bug in gnssro_module

### DIFF
--- a/obs2ioda-v2/src/gnssro_mod.f90
+++ b/obs2ioda-v2/src/gnssro_mod.f90
@@ -13,7 +13,6 @@ integer, parameter :: i_kind  = selected_int_kind(8)    !4
 integer, parameter :: i_64    = selected_int_kind(10)   !8
 integer, parameter :: r_kind  = selected_real_kind(15)  !8
 
-integer(i_kind) :: said
 logical :: verbose = .false.
 
 contains
@@ -308,7 +307,7 @@ do while(ireadmg(lnbufr,subset,idate)==0)
        gnssro_data%rfict(ndata) = roc
        gnssro_data%geoid(ndata) = geoid
        gnssro_data%azim(ndata)  = azim
-       CALL bendingangle_err_gsi(rlat,impact-roc, obsErr, ogce)
+       CALL bendingangle_err_gsi(rlat,impact-roc, obsErr, ogce, said)
        gnssro_data%bndoe_gsi(ndata) = obsErr
        if ( ref > r_missing)  then
           CALL refractivity_err_gsi(rlat,height, GlobalModel, obsErr)
@@ -557,9 +556,9 @@ endif
 
 end subroutine refractivity_err_gsi
 
-subroutine  bendingangle_err_gsi(obsLat, obsZ,  obsErr, ogce)
+subroutine  bendingangle_err_gsi(obsLat, obsZ,  obsErr, ogce, said)
 real(r_kind), intent(in)   :: obsLat,  obsZ
-integer,        intent(in) :: ogce
+integer(i_kind), intent(in) :: ogce, said
 real(r_kind), intent(out)  :: obsErr
 real(r_kind)               :: obsZ_km
 


### PR DESCRIPTION
### Description
This PR fixes a satellite ID bug in subroutine bendingangle_err_gsi. Previously, the module defined a global variable said and a local variable said in subroutine read_write_gnssro. The local variable was initialized in read_write_gnssro, while the global variable remained uninitialized. Subroutine bengingangle_err_gsi incorrectly used the uninitialized global variable instead of the local one, which made the said comparisons meaningless. This PR removes the global variable and passes the local variable to bendingangle_err_gsi.

### Tests completed
Ran example BUFR file conversion and verified that the said passed to bendingangle_err_gsi is nonzero.