### PR TITLE
Support for Creating and Setting NetCDF Variables

### DIFF
--- a/obs2ioda-v2/src/cxx/CMakeLists.txt
+++ b/obs2ioda-v2/src/cxx/CMakeLists.txt
@@ -3,6 +3,7 @@ set(obs2ioda_cxx_SOURCES
     netcdf_file.cc
     netcdf_group.cc
     netcdf_dimension.cc
+    netcdf_variable.cc
 )
 set(obs2ioda_cxx_LIBRARIES
     NetCDF::NetCDF_CXX

--- a/obs2ioda-v2/src/cxx/netcdf_variable.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_variable.cc
@@ -44,7 +44,7 @@ namespace Obs2Ioda {
         int netcdfID,
         const char *groupName,
         const char *varName,
-        const T *data
+        const T *values
     ) {
         try {
             auto file = FileMap::getInstance().getFile(netcdfID);
@@ -55,7 +55,7 @@ namespace Obs2Ioda {
                                        file->getGroup(
                                            groupName));
             auto var = group->getVar(varName);
-            var.putVar(data);
+            var.putVar(values);
             return 0;
         } catch (netCDF::exceptions::NcException &e) {
             return netcdfErrorMessage(
@@ -70,13 +70,13 @@ namespace Obs2Ioda {
         int netcdfID,
         const char *groupName,
         const char *varName,
-        const int *data
+        const int *values
     ) {
         return netcdfPutVar(
             netcdfID,
             groupName,
             varName,
-            data
+            values
         );
     }
 
@@ -84,13 +84,13 @@ namespace Obs2Ioda {
         int netcdfID,
         const char *groupName,
         const char *varName,
-        const long long *data
+        const long long *values
     ) {
         return netcdfPutVar(
             netcdfID,
             groupName,
             varName,
-            data
+            values
         );
     }
 
@@ -98,13 +98,13 @@ namespace Obs2Ioda {
         int netcdfID,
         const char *groupName,
         const char *varName,
-        const float *data
+        const float *values
     ) {
         return netcdfPutVar(
             netcdfID,
             groupName,
             varName,
-            data
+            values
         );
     }
 
@@ -112,13 +112,13 @@ namespace Obs2Ioda {
         int netcdfID,
         const char *groupName,
         const char *varName,
-        const char **data
+        const char **values
     ) {
         return netcdfPutVar(
             netcdfID,
             groupName,
             varName,
-            data
+            values
         );
     }
 

--- a/obs2ioda-v2/src/cxx/netcdf_variable.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_variable.cc
@@ -1,0 +1,361 @@
+#include "netcdf_variable.h"
+#include "netcdf_file.h"
+#include "netcdf_error.h"
+#include <algorithm>
+#include <mutex>
+
+namespace Obs2Ioda {
+    template int netcdfGetVar<int>(
+        int,
+        const char *,
+        const char *,
+        int **
+    );
+
+    template int netcdfGetVar<long long>(
+        int,
+        const char *,
+        const char *,
+        long long **
+    );
+
+    template int netcdfGetVar<float>(
+        int,
+        const char *,
+        const char *,
+        float **
+    );
+
+    template int netcdfSetFill<int>(
+        int,
+        const char *,
+        const char *,
+        int,
+        int);
+
+    template int netcdfSetFill<float>(
+        int,
+        const char *,
+        const char *,
+        int,
+        float);
+
+    template int netcdfSetFill<long long>(
+        int,
+        const char *,
+        const char *,
+        int,
+        long long);
+
+    template int netcdfSetFill<const char *>(
+        int,
+        const char *,
+        const char *,
+        int,
+        const char *
+    );
+
+    template int netcdfSetFill<const char>(
+        int,
+        const char *,
+        const char *,
+        int,
+        const char);
+
+    template int netcdfPutVar<int>(
+        int,
+        const char *,
+        const char *,
+        const int *
+    );
+
+    template int netcdfPutVar<float>(
+        int,
+        const char *,
+        const char *,
+        const float *
+    );
+
+    int netcdfAddVar(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        nc_type netcdfDataType,
+        int numDims,
+        const char **dimNames
+    ) {
+        try {
+            const auto file = FileMap::getInstance().getFile(netcdfID);
+            const auto group = !groupName
+                                   ? file
+                                   : std::make_shared<
+                                       netCDF::NcGroup>(
+                                       file->getGroup(
+                                           groupName));
+            std::vector<netCDF::NcDim> dims;
+            dims.reserve(numDims);
+            for (int i = 0; i < numDims; i++) {
+                dims.push_back(file->getDim(dimNames[i]));;
+            }
+            auto var = group->addVar(
+                varName,
+                netCDF::NcType(netcdfDataType),
+                dims
+            );
+            return 0;
+        } catch (netCDF::exceptions::NcException &e) {
+            return netcdfErrorMessage(
+                e,
+                __LINE__,
+                __FILE__
+            );
+        }
+    }
+
+    template<typename T>
+    int netcdfPutVar(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        const T *data
+    ) {
+        try {
+            const auto file = FileMap::getInstance().getFile(netcdfID);
+            const auto group = !groupName
+                                   ? file
+                                   : std::make_shared<
+                                       netCDF::NcGroup>(
+                                       file->getGroup(
+                                           groupName));
+            auto var = group->getVar(varName);
+            var.putVar(data);
+            return 0;
+        } catch (netCDF::exceptions::NcException &e) {
+            return netcdfErrorMessage(
+                e,
+                __LINE__,
+                __FILE__
+            );
+        }
+    }
+
+    int netcdfPutVarInt(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        const int *data
+    ) {
+        return netcdfPutVar(
+            netcdfID,
+            groupName,
+            varName,
+            data
+        );
+    }
+
+    int netcdfPutVarInt64(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        const long long *data
+    ) {
+        return netcdfPutVar(
+            netcdfID,
+            groupName,
+            varName,
+            data
+        );
+    }
+
+    int netcdfPutVarReal(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        const float *data
+    ) {
+        return netcdfPutVar(
+            netcdfID,
+            groupName,
+            varName,
+            data
+        );
+    }
+
+    int netcdfPutVarString(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        const char **data
+    ) {
+        return netcdfPutVar(
+            netcdfID,
+            groupName,
+            varName,
+            data
+        );
+    }
+
+
+    template<typename T>
+    int netcdfGetVar(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        T **data
+    ) {
+        try {
+            const auto file = FileMap::getInstance().getFile(netcdfID);
+            const auto group = !groupName
+                                   ? file
+                                   : std::make_shared<
+                                       netCDF::NcGroup>(
+                                       file->getGroup(
+                                           groupName));
+            auto var = group->getVar(varName);
+            const std::vector<size_t> start = {0};
+            const std::vector<size_t> count = {var.getDim(0).getSize()};
+            var.getVar(
+                start,
+                count,
+                *data
+            );
+            return 0;
+        } catch (netCDF::exceptions::NcException &e) {
+            return netcdfErrorMessage(
+                e,
+                __LINE__,
+                __FILE__
+            );
+        }
+    }
+
+    template<typename T>
+    int netcdfSetFill(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        int fillMode,
+        T fillValue
+    ) {
+        try {
+            const auto file = FileMap::getInstance().getFile(netcdfID);
+            const auto group = !groupName
+                                   ? file
+                                   : std::make_shared<
+                                       netCDF::NcGroup>(
+                                       file->getGroup(
+                                           groupName));
+            auto var = group->getVar(varName);
+            var.setFill(
+                fillMode,
+                fillValue
+            );
+            return 0;
+        } catch (netCDF::exceptions::NcException &e) {
+            return netcdfErrorMessage(
+                e,
+                __LINE__,
+                __FILE__
+            );
+        }
+    }
+
+    int netcdfSetFillInt(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        int fillMode,
+        int fillValue
+    ) {
+        return netcdfSetFill(
+            netcdfID,
+            groupName,
+            varName,
+            fillMode,
+            fillValue
+        );
+    }
+
+    int netcdfSetFillReal(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        int fillMode,
+        float fillValue
+    ) {
+        return netcdfSetFill(
+            netcdfID,
+            groupName,
+            varName,
+            fillMode,
+            fillValue
+        );
+    }
+
+    int netcdfSetFillInt64(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        int fillMode,
+        long long fillValue
+    ) {
+        return netcdfSetFill(
+            netcdfID,
+            groupName,
+            varName,
+            fillMode,
+            fillValue
+        );
+    }
+
+    int netcdfSetFillString(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        int fillMode,
+        const char *fillValue
+    ) {
+        return netcdfSetFill(
+            netcdfID,
+            groupName,
+            varName,
+            fillMode,
+            fillValue
+
+        );
+    }
+
+    int netcdfGetVarString1D(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        char ***data
+    ) {
+        auto file = FileMap::getInstance().getFile(netcdfID);
+        auto dims = file->getVar(varName).getDims();
+        auto var = file->getVar(varName);
+        size_t numStrings = dims[0].getSize();
+        char **buffer = new char *[numStrings];
+        int retval = netcdfGetVar(
+            netcdfID,
+            groupName,
+            varName,
+            &buffer
+        );
+        for (auto i = 0; i < numStrings; i++) {
+            std::string tmpStr = buffer[i];
+            std::copy(
+                tmpStr.begin(),
+                tmpStr.end(),
+                (*data)[i]
+            );
+            (*data)[i][tmpStr.size()] = '\0';
+        }
+        var.freeString(
+            numStrings,
+            (char **) buffer
+        );
+        free(buffer);
+        return retval;
+    }
+}

--- a/obs2ioda-v2/src/cxx/netcdf_variable.h
+++ b/obs2ioda-v2/src/cxx/netcdf_variable.h
@@ -35,7 +35,7 @@ namespace Obs2Ioda {
     * @param netcdfID The identifier of the NetCDF file where the data will be written.
     * @param groupName The name of the group containing the variable. If nullptr, the variable is assumed to be in the root group.
     * @param varName The name of the variable to which data will be written.
-    * @param data A pointer to the data to be written to the variable.
+    * @param values A pointer to the data to be written to the variable.
     * @return int A status code indicating the outcome of the operation:
     *         - 0: Success.
     *         - Non-zero: Failure, with an error message logged.
@@ -44,28 +44,28 @@ namespace Obs2Ioda {
         int netcdfID,
         const char *groupName,
         const char *varName,
-        const int *data
+        const int *values
     );
 
     int netcdfPutVarInt64(
         int netcdfID,
         const char *groupName,
         const char *varName,
-        const long long *data
+        const long long *values
     );
 
     int netcdfPutVarReal(
         int netcdfID,
         const char *groupName,
         const char *varName,
-        const float *data
+        const float *values
     );
 
     int netcdfPutVarString(
         int netcdfID,
         const char *groupName,
         const char *varName,
-        const char **data
+        const char **values
     );
 
     /**

--- a/obs2ioda-v2/src/cxx/netcdf_variable.h
+++ b/obs2ioda-v2/src/cxx/netcdf_variable.h
@@ -31,7 +31,6 @@ namespace Obs2Ioda {
     /**
     * @brief Writes data to a variable in a NetCDF file.
     *
-    * @tparam T The data type of the variable.
     * @param netcdfID The identifier of the NetCDF file where the data will be written.
     * @param groupName The name of the group containing the variable. If nullptr, the variable is assumed to be in the root group.
     * @param varName The name of the variable to which data will be written.
@@ -71,7 +70,6 @@ namespace Obs2Ioda {
     /**
     * @brief Sets the fill mode and fill value for a variable in a NetCDF file.
     *
-    * @tparam T The data type of the fill value.
     * @param netcdfID The identifier of the NetCDF file containing the variable.
     * @param groupName The name of the group containing the variable. If nullptr, the variable is assumed to be in the root group.
     * @param varName The name of the variable for which the fill mode is set.

--- a/obs2ioda-v2/src/cxx/netcdf_variable.h
+++ b/obs2ioda-v2/src/cxx/netcdf_variable.h
@@ -3,88 +3,22 @@
 #include <netcdf>
 
 namespace Obs2Ioda {
-    /**
-* @brief Writes data to a NetCDF variable.
-*
-* This function writes data of any supported type (`T`) to a variable in a NetCDF file,
-* within the specified group or the root group.
-*
-* @tparam T The data type of the variable (e.g., `int`, `float`, `double`, etc.).
-* @param netcdfID The identifier of the NetCDF file.
-* @param groupName A null-terminated string specifying the group containing the variable.
-*                  If `nullptr`, the variable is assumed to be in the root group.
-* @param varName A null-terminated string specifying the name of the variable.
-* @param data A pointer to the data to be written to the variable.
-* @return 0 on success, non-zero on failure.
-*/
-    template<typename T>
-    int netcdfPutVar(
-        int netcdfID,
-        const char *groupName,
-        const char *varName,
-        const T *data
-    );
-
-    /**
- * @brief Reads data from a NetCDF variable.
- *
- * This function reads data of any supported type (`T`) from a variable in a NetCDF file,
- * within the specified group or the root group.
- *
- * @tparam T The data type of the variable (e.g., `int`, `float`, `double`, etc.).
- * @param netcdfID The identifier of the NetCDF file.
- * @param groupName A null-terminated string specifying the group containing the variable.
- *                  If `nullptr`, the variable is assumed to be in the root group.
- * @param varName A null-terminated string specifying the name of the variable.
- * @param data A pointer to a pointer that will receive the data read from the variable.
- *             Memory for the data will be allocated by the function.
- * @return 0 on success, non-zero on failure.
- */
-
-    template<typename T>
-    int netcdfGetVar(
-        int netcdfID,
-        const char *groupName,
-        const char *varName,
-        T **data
-    );
-
-    /**
-     * @brief Sets the fill mode and fill value for a NetCDF variable.
-     *
-     * This function sets the fill mode and optional fill value for a variable in a NetCDF file.
-     *
-     * @tparam T The data type of the fill value (e.g., `int`, `float`, etc.).
-     * @param netcdfID The identifier of the NetCDF file.
-     * @param groupName A null-terminated string specifying the group containing the variable.
-     *                  If `nullptr`, the variable is assumed to be in the root group.
-     * @param varName A null-terminated string specifying the name of the variable.
-     * @param fillMode The fill mode to be set.
-     * @param fillValue The fill value to be set for the variable.
-     * @return 0 on success, non-zero on failure.
-     */
-    template<typename T>
-    int netcdfSetFill(
-        int netcdfID,
-        const char *groupName,
-        const char *varName,
-        int fillMode,
-        T fillValue
-    );
 
     extern "C" {
     /**
-* @brief Adds a variable to a NetCDF file.
-*
-* @param netcdfID The identifier of the NetCDF file.
-* @param groupName A null-terminated string specifying the group to which the variable will be added.
-*                  If `nullptr`, the variable is added to the root group.
-* @param varName A null-terminated string specifying the name of the variable.
-* @param netcdfDataType The NetCDF data type of the variable (e.g., `NC_INT`, `NC_FLOAT`).
-* @param numDims The number of dimensions for the variable.
-* @param dimNames An array of null-terminated strings specifying the names of the dimensions.
-* @return 0 on success, non-zero on failure.
-*/
+     * @brief Adds a variable to a NetCDF file.
+     *
+     * @param netcdfID The identifier of the NetCDF file where the variable will be added.
+     * @param groupName The name of the group in which the variable should be created.
+     *                  If nullptr, the variable is added to the root group.
+     * @param varName The name of the variable to be created.
+     * @param netcdfDataType The NetCDF data type of the variable (e.g., NC_INT, NC_FLOAT).
+     * @param numDims The number of dimensions associated with the variable.
+     * @param dimNames An array of dimension names specifying the shape of the variable.
+     * @return int A status code indicating the outcome of the operation:
+     *         - 0: Success.
+     *         - Non-zero: Failure, with an error message logged.
+     */
     int netcdfAddVar(
         int netcdfID,
         const char *groupName,
@@ -94,6 +28,18 @@ namespace Obs2Ioda {
         const char **dimNames
     );
 
+    /**
+    * @brief Writes data to a variable in a NetCDF file.
+    *
+    * @tparam T The data type of the variable.
+    * @param netcdfID The identifier of the NetCDF file where the data will be written.
+    * @param groupName The name of the group containing the variable. If nullptr, the variable is assumed to be in the root group.
+    * @param varName The name of the variable to which data will be written.
+    * @param data A pointer to the data to be written to the variable.
+    * @return int A status code indicating the outcome of the operation:
+    *         - 0: Success.
+    *         - Non-zero: Failure, with an error message logged.
+    */
     int netcdfPutVarInt(
         int netcdfID,
         const char *groupName,
@@ -122,13 +68,21 @@ namespace Obs2Ioda {
         const char **data
     );
 
-    int netcdfGetVarString1D(
-        int netcdfID,
-        const char *groupName,
-        const char *varName,
-        char ***data
-    );
-
+    /**
+    * @brief Sets the fill mode and fill value for a variable in a NetCDF file.
+    *
+    * @tparam T The data type of the fill value.
+    * @param netcdfID The identifier of the NetCDF file containing the variable.
+    * @param groupName The name of the group containing the variable. If nullptr, the variable is assumed to be in the root group.
+    * @param varName The name of the variable for which the fill mode is set.
+    * @param fillMode The fill mode to be applied:
+    *         - 0: Disable fill mode (use uninitialized values).
+    *         - 1: Enable fill mode (use the specified fill value).
+    * @param fillValue The fill value to be applied when fill mode is enabled. Must match the data type of the variable.
+    * @return int A status code indicating the outcome of the operation:
+    *         - 0: Success.
+    *         - Non-zero: Failure, with an error message logged.
+    */
     int netcdfSetFillInt(
         int netcdfID,
         const char *groupName,

--- a/obs2ioda-v2/src/cxx/netcdf_variable.h
+++ b/obs2ioda-v2/src/cxx/netcdf_variable.h
@@ -1,0 +1,166 @@
+#ifndef NETCDF_VARIABLE_H
+#define NETCDF_VARIABLE_H
+#include <netcdf>
+
+namespace Obs2Ioda {
+    /**
+* @brief Writes data to a NetCDF variable.
+*
+* This function writes data of any supported type (`T`) to a variable in a NetCDF file,
+* within the specified group or the root group.
+*
+* @tparam T The data type of the variable (e.g., `int`, `float`, `double`, etc.).
+* @param netcdfID The identifier of the NetCDF file.
+* @param groupName A null-terminated string specifying the group containing the variable.
+*                  If `nullptr`, the variable is assumed to be in the root group.
+* @param varName A null-terminated string specifying the name of the variable.
+* @param data A pointer to the data to be written to the variable.
+* @return 0 on success, non-zero on failure.
+*/
+    template<typename T>
+    int netcdfPutVar(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        const T *data
+    );
+
+    /**
+ * @brief Reads data from a NetCDF variable.
+ *
+ * This function reads data of any supported type (`T`) from a variable in a NetCDF file,
+ * within the specified group or the root group.
+ *
+ * @tparam T The data type of the variable (e.g., `int`, `float`, `double`, etc.).
+ * @param netcdfID The identifier of the NetCDF file.
+ * @param groupName A null-terminated string specifying the group containing the variable.
+ *                  If `nullptr`, the variable is assumed to be in the root group.
+ * @param varName A null-terminated string specifying the name of the variable.
+ * @param data A pointer to a pointer that will receive the data read from the variable.
+ *             Memory for the data will be allocated by the function.
+ * @return 0 on success, non-zero on failure.
+ */
+
+    template<typename T>
+    int netcdfGetVar(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        T **data
+    );
+
+    /**
+     * @brief Sets the fill mode and fill value for a NetCDF variable.
+     *
+     * This function sets the fill mode and optional fill value for a variable in a NetCDF file.
+     *
+     * @tparam T The data type of the fill value (e.g., `int`, `float`, etc.).
+     * @param netcdfID The identifier of the NetCDF file.
+     * @param groupName A null-terminated string specifying the group containing the variable.
+     *                  If `nullptr`, the variable is assumed to be in the root group.
+     * @param varName A null-terminated string specifying the name of the variable.
+     * @param fillMode The fill mode to be set (e.g., `NC_FILL` or `NC_NOFILL`).
+     * @param fillValue The fill value to be set for the variable (optional if `fillMode` is `NC_NOFILL`).
+     * @return 0 on success, non-zero on failure.
+     */
+    template<typename T>
+    int netcdfSetFill(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        int fillMode,
+        T fillValue
+    );
+
+    extern "C" {
+        /**
+ * @brief Adds a variable to a NetCDF file.
+ *
+ * @param netcdfID The identifier of the NetCDF file.
+ * @param groupName A null-terminated string specifying the group to which the variable will be added.
+ *                  If `nullptr`, the variable is added to the root group.
+ * @param varName A null-terminated string specifying the name of the variable.
+ * @param netcdfDataType The NetCDF data type of the variable (e.g., `NC_INT`, `NC_FLOAT`).
+ * @param numDims The number of dimensions for the variable.
+ * @param dimNames An array of null-terminated strings specifying the names of the dimensions.
+ * @return 0 on success, non-zero on failure.
+ */
+    int netcdfAddVar(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        nc_type netcdfDataType,
+        int numDims,
+        const char **dimNames
+    );
+
+    int netcdfPutVarInt(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        const int *data
+    );
+
+    int netcdfPutVarInt64(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        const long long *data
+    );
+
+    int netcdfPutVarReal(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        const float *data
+    );
+
+    int netcdfPutVarString(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        const char **data
+    );
+
+    int netcdfGetVarString1D(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        char ***data
+    );
+
+    int netcdfSetFillInt(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        int fillMode,
+        int fillValue
+    );
+
+    int netcdfSetFillReal(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        int fillMode,
+        float fillValue
+    );
+
+    int netcdfSetFillInt64(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        int fillMode,
+        long long fillValue
+    );
+
+    int netcdfSetFillString(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        int fillMode,
+        const char *fillValue
+    );
+    }
+}
+
+#endif //NETCDF_VARIABLE_H

--- a/obs2ioda-v2/src/cxx/netcdf_variable.h
+++ b/obs2ioda-v2/src/cxx/netcdf_variable.h
@@ -59,8 +59,8 @@ namespace Obs2Ioda {
      * @param groupName A null-terminated string specifying the group containing the variable.
      *                  If `nullptr`, the variable is assumed to be in the root group.
      * @param varName A null-terminated string specifying the name of the variable.
-     * @param fillMode The fill mode to be set (e.g., `NC_FILL` or `NC_NOFILL`).
-     * @param fillValue The fill value to be set for the variable (optional if `fillMode` is `NC_NOFILL`).
+     * @param fillMode The fill mode to be set.
+     * @param fillValue The fill value to be set for the variable.
      * @return 0 on success, non-zero on failure.
      */
     template<typename T>
@@ -73,18 +73,18 @@ namespace Obs2Ioda {
     );
 
     extern "C" {
-        /**
- * @brief Adds a variable to a NetCDF file.
- *
- * @param netcdfID The identifier of the NetCDF file.
- * @param groupName A null-terminated string specifying the group to which the variable will be added.
- *                  If `nullptr`, the variable is added to the root group.
- * @param varName A null-terminated string specifying the name of the variable.
- * @param netcdfDataType The NetCDF data type of the variable (e.g., `NC_INT`, `NC_FLOAT`).
- * @param numDims The number of dimensions for the variable.
- * @param dimNames An array of null-terminated strings specifying the names of the dimensions.
- * @return 0 on success, non-zero on failure.
- */
+    /**
+* @brief Adds a variable to a NetCDF file.
+*
+* @param netcdfID The identifier of the NetCDF file.
+* @param groupName A null-terminated string specifying the group to which the variable will be added.
+*                  If `nullptr`, the variable is added to the root group.
+* @param varName A null-terminated string specifying the name of the variable.
+* @param netcdfDataType The NetCDF data type of the variable (e.g., `NC_INT`, `NC_FLOAT`).
+* @param numDims The number of dimensions for the variable.
+* @param dimNames An array of null-terminated strings specifying the names of the dimensions.
+* @return 0 on success, non-zero on failure.
+*/
     int netcdfAddVar(
         int netcdfID,
         const char *groupName,

--- a/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
@@ -112,6 +112,134 @@ module netcdf_cxx_i_mod
             integer(c_int) :: c_netcdfAddDim
         end function c_netcdfAddDim
 
+        ! c_netcdfAddVar:
+        !   Adds a new variable to a NetCDF file, specifying its name, type, and associated dimensions.
+        !
+        !   Arguments:
+        !     - netcdfID (integer(c_int), intent(in), value):
+        !       The identifier of the NetCDF file where the variable will be created.
+        !     - groupName (type(c_ptr), intent(in), value):
+        !       A C pointer to a null-terminated string specifying the group name. If `c_null_ptr`,
+        !       the variable is added as a global variable.
+        !     - varName (type(c_ptr), intent(in), value):
+        !       A C pointer to a null-terminated string specifying the variable name.
+        !     - netcdfDataType (integer(c_int), intent(in), value):
+        !       The NetCDF data type of the variable (e.g., `NF90_INT`, `NF90_REAL`).
+        !     - numDims (integer(c_int), intent(in), value):
+        !       The number of dimensions associated with the variable.
+        !     - dimNames (type(c_ptr), intent(in), value):
+        !       A C pointer to an array of null-terminated strings representing the dimension names.
+        !
+        !   Returns:
+        !     - integer(c_int): Status code indicating the result of the operation:
+        !         - 0: Success.
+        !         - Non-zero: Failure.
+        !
+        !   Notes:
+        !     - This function assumes that `netcdfID` corresponds to a valid NetCDF file.
+        !     - All strings must be null-terminated and passed as C pointers.
+        function c_netcdfAddVar(&
+                netcdfID, groupName, varName, netcdfDataType, numDims, dimNames) &
+                bind(C, name = "netcdfAddVar")
+            import :: c_int
+            import :: c_ptr
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: groupName
+            type(c_ptr), value, intent(in) :: varName
+            integer(c_int), value, intent(in) :: netcdfDataType
+            integer(c_int), value, intent(in) :: numDims
+            type(c_ptr), value, intent(in) :: dimNames
+            integer(c_int) :: c_netcdfAddVar
+        end function c_netcdfAddVar
+
+        ! c_netcdfPutVarInt:
+        !   Writes integer data to a NetCDF variable in the specified group or as a global variable.
+        !
+        !   Arguments:
+        !     - netcdfID (integer(c_int), intent(in), value):
+        !       The identifier of the NetCDF file.
+        !     - groupName (type(c_ptr), intent(in), value):
+        !       A C pointer to a null-terminated string specifying the group name. If `c_null_ptr`,
+        !       the variable is assumed to be a global variable.
+        !     - varName (type(c_ptr), intent(in), value):
+        !       A C pointer to a null-terminated string specifying the variable name.
+        !     - data (type(c_ptr), intent(in), value):
+        !       A C pointer to the array of integer data to be written.
+        !
+        !   Returns:
+        !     - integer(c_int): Status code indicating the result of the operation:
+        !         - 0: Success.
+        !         - Non-zero: Failure.
+        function c_netcdfPutVarInt(&
+                netcdfID, groupName, varName, data) &
+                bind(C, name = "netcdfPutVarInt")
+            import :: c_int
+            import :: c_ptr
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: groupName
+            type(c_ptr), value, intent(in) :: varName
+            type(c_ptr), value, intent(in) :: data
+            integer(c_int) :: c_netcdfPutVarInt
+        end function c_netcdfPutVarInt
+
+        ! c_netcdfPutVarInt64:
+        !   Writes 64-bit integer data to a NetCDF variable in the specified group or as a global variable.
+        function c_netcdfPutVarInt64(&
+                netcdfID, groupName, varName, data) &
+                bind(C, name = "netcdfPutVarInt64")
+            import :: c_int
+            import :: c_ptr
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: groupName
+            type(c_ptr), value, intent(in) :: varName
+            type(c_ptr), value, intent(in) :: data
+            integer(c_int) :: c_netcdfPutVarInt64
+        end function c_netcdfPutVarInt64
+
+        ! c_netcdfPutVarReal:
+        !   Writes real (floating-point) data to a NetCDF variable in the specified group or as a global variable.
+        function c_netcdfPutVarReal(&
+                netcdfID, groupName, varName, data) &
+                bind(C, name = "netcdfPutVarReal")
+            import :: c_int
+            import :: c_ptr
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: groupName
+            type(c_ptr), value, intent(in) :: varName
+            type(c_ptr), value, intent(in) :: data
+            integer(c_int) :: c_netcdfPutVarReal
+        end function c_netcdfPutVarReal
+
+        ! c_netcdfPutVarString:
+        !   Writes string data to a NetCDF variable in the specified group or as a global variable.
+        !
+        !   Arguments:
+        !     - netcdfID (integer(c_int), intent(in), value):
+        !       The identifier of the NetCDF file.
+        !     - groupName (type(c_ptr), intent(in), value):
+        !       A C pointer to a null-terminated string specifying the group name. If `c_null_ptr`,
+        !       the variable is assumed to be a global variable.
+        !     - varName (type(c_ptr), intent(in), value):
+        !       A C pointer to a null-terminated string specifying the variable name.
+        !     - data (type(c_ptr), intent(in), value):
+        !       A C pointer to the array of strings to be written.
+        !
+        !   Returns:
+        !     - integer(c_int): Status code indicating the result of the operation:
+        !         - 0: Success.
+        !         - Non-zero: Failure.
+        function c_netcdfPutVarString(&
+                netcdfID, groupName, varName, data) &
+                bind(C, name = "netcdfPutVarString")
+            import :: c_int
+            import :: c_ptr
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: groupName
+            type(c_ptr), value, intent(in) :: varName
+            type(c_ptr), value, intent(in) :: data
+            integer(c_int) :: c_netcdfPutVarString
+        end function c_netcdfPutVarString
+
     end interface
 
 end module netcdf_cxx_i_mod

--- a/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
@@ -163,7 +163,7 @@ module netcdf_cxx_i_mod
         !       the variable is assumed to be a global variable.
         !     - varName (type(c_ptr), intent(in), value):
         !       A C pointer to a null-terminated string specifying the variable name.
-        !     - data (type(c_ptr), intent(in), value):
+        !     - values (type(c_ptr), intent(in), value):
         !       A C pointer to the array of integer data to be written.
         !
         !   Returns:
@@ -171,53 +171,53 @@ module netcdf_cxx_i_mod
         !         - 0: Success.
         !         - Non-zero: Failure.
         function c_netcdfPutVarInt(&
-                netcdfID, groupName, varName, data) &
+                netcdfID, groupName, varName, values) &
                 bind(C, name = "netcdfPutVarInt")
             import :: c_int
             import :: c_ptr
             integer(c_int), value, intent(in) :: netcdfID
             type(c_ptr), value, intent(in) :: groupName
             type(c_ptr), value, intent(in) :: varName
-            type(c_ptr), value, intent(in) :: data
+            type(c_ptr), value, intent(in) :: values
             integer(c_int) :: c_netcdfPutVarInt
         end function c_netcdfPutVarInt
 
         ! See documentation for `c_netcdfPutVarInt`.
         function c_netcdfPutVarInt64(&
-                netcdfID, groupName, varName, data) &
+                netcdfID, groupName, varName, values) &
                 bind(C, name = "netcdfPutVarInt64")
             import :: c_int
             import :: c_ptr
             integer(c_int), value, intent(in) :: netcdfID
             type(c_ptr), value, intent(in) :: groupName
             type(c_ptr), value, intent(in) :: varName
-            type(c_ptr), value, intent(in) :: data
+            type(c_ptr), value, intent(in) :: values
             integer(c_int) :: c_netcdfPutVarInt64
         end function c_netcdfPutVarInt64
 
         ! See documentation for `c_netcdfPutVarInt`.
         function c_netcdfPutVarReal(&
-                netcdfID, groupName, varName, data) &
+                netcdfID, groupName, varName, values) &
                 bind(C, name = "netcdfPutVarReal")
             import :: c_int
             import :: c_ptr
             integer(c_int), value, intent(in) :: netcdfID
             type(c_ptr), value, intent(in) :: groupName
             type(c_ptr), value, intent(in) :: varName
-            type(c_ptr), value, intent(in) :: data
+            type(c_ptr), value, intent(in) :: values
             integer(c_int) :: c_netcdfPutVarReal
         end function c_netcdfPutVarReal
 
         ! See documentation for `c_netcdfPutVarInt`.
         function c_netcdfPutVarString(&
-                netcdfID, groupName, varName, data) &
+                netcdfID, groupName, varName, values) &
                 bind(C, name = "netcdfPutVarString")
             import :: c_int
             import :: c_ptr
             integer(c_int), value, intent(in) :: netcdfID
             type(c_ptr), value, intent(in) :: groupName
             type(c_ptr), value, intent(in) :: varName
-            type(c_ptr), value, intent(in) :: data
+            type(c_ptr), value, intent(in) :: values
             integer(c_int) :: c_netcdfPutVarString
         end function c_netcdfPutVarString
 

--- a/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
@@ -1,5 +1,5 @@
 module netcdf_cxx_i_mod
-    use iso_c_binding, only : c_int, c_ptr
+    use iso_c_binding, only : c_int, c_ptr, c_float, c_long
     implicit none
     public
 
@@ -152,7 +152,7 @@ module netcdf_cxx_i_mod
             integer(c_int) :: c_netcdfAddVar
         end function c_netcdfAddVar
 
-        ! c_netcdfPutVarInt:
+        ! c_netcdfPutVar:
         !   Writes integer data to a NetCDF variable in the specified group or as a global variable.
         !
         !   Arguments:
@@ -182,8 +182,7 @@ module netcdf_cxx_i_mod
             integer(c_int) :: c_netcdfPutVarInt
         end function c_netcdfPutVarInt
 
-        ! c_netcdfPutVarInt64:
-        !   Writes 64-bit integer data to a NetCDF variable in the specified group or as a global variable.
+        ! See documentation for `c_netcdfPutVarInt`.
         function c_netcdfPutVarInt64(&
                 netcdfID, groupName, varName, data) &
                 bind(C, name = "netcdfPutVarInt64")
@@ -196,8 +195,7 @@ module netcdf_cxx_i_mod
             integer(c_int) :: c_netcdfPutVarInt64
         end function c_netcdfPutVarInt64
 
-        ! c_netcdfPutVarReal:
-        !   Writes real (floating-point) data to a NetCDF variable in the specified group or as a global variable.
+        ! See documentation for `c_netcdfPutVarInt`.
         function c_netcdfPutVarReal(&
                 netcdfID, groupName, varName, data) &
                 bind(C, name = "netcdfPutVarReal")
@@ -210,24 +208,7 @@ module netcdf_cxx_i_mod
             integer(c_int) :: c_netcdfPutVarReal
         end function c_netcdfPutVarReal
 
-        ! c_netcdfPutVarString:
-        !   Writes string data to a NetCDF variable in the specified group or as a global variable.
-        !
-        !   Arguments:
-        !     - netcdfID (integer(c_int), intent(in), value):
-        !       The identifier of the NetCDF file.
-        !     - groupName (type(c_ptr), intent(in), value):
-        !       A C pointer to a null-terminated string specifying the group name. If `c_null_ptr`,
-        !       the variable is assumed to be a global variable.
-        !     - varName (type(c_ptr), intent(in), value):
-        !       A C pointer to a null-terminated string specifying the variable name.
-        !     - data (type(c_ptr), intent(in), value):
-        !       A C pointer to the array of strings to be written.
-        !
-        !   Returns:
-        !     - integer(c_int): Status code indicating the result of the operation:
-        !         - 0: Success.
-        !         - Non-zero: Failure.
+        ! See documentation for `c_netcdfPutVarInt`.
         function c_netcdfPutVarString(&
                 netcdfID, groupName, varName, data) &
                 bind(C, name = "netcdfPutVarString")
@@ -239,6 +220,84 @@ module netcdf_cxx_i_mod
             type(c_ptr), value, intent(in) :: data
             integer(c_int) :: c_netcdfPutVarString
         end function c_netcdfPutVarString
+
+        ! c_netcdfSetFillInt:
+        !   Sets the fill mode and fill value for an integer NetCDF variable in the specified group
+        !   or as a global variable.
+        !
+        !   Arguments:
+        !     - netcdfID (integer(c_int), intent(in), value):
+        !       The identifier of the NetCDF file.
+        !     - groupName (type(c_ptr), intent(in), value):
+        !       A C pointer to a null-terminated string specifying the group name. If `c_null_ptr`,
+        !       the variable is assumed to be a global variable.
+        !     - varName (type(c_ptr), intent(in), value):
+        !       A C pointer to a null-terminated string specifying the variable name.
+        !     - fillMode (integer(c_int), intent(in), value):
+        !       The fill mode flag, typically `NC_FILL` (enable fill) or `NC_NOFILL` (disable fill).
+        !     - fillValue (integer(c_int), intent(in), value):
+        !       The integer fill value to be used if fill mode is enabled.
+        !
+        !   Returns:
+        !     - integer(c_int): Status code indicating the result of the operation:
+        !         - 0: Success.
+        !         - Non-zero: Failure.
+        function c_netcdfSetFillInt(&
+                netcdfID, groupName, varName, fillMode, fillValue) &
+                bind(C, name = "netcdfSetFillInt")
+            import :: c_int
+            import :: c_ptr
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: groupName
+            type(c_ptr), value, intent(in) :: varName
+            integer(c_int), value, intent(in) :: fillMode
+            integer(c_int), value, intent(in) :: fillValue
+            integer(c_int) :: c_netcdfSetFillInt
+        end function c_netcdfSetFillInt
+
+        ! See documentation for `c_netcdfSetFillInt`.
+        function c_netcdfSetFillInt64(&
+                netcdfID, groupName, varName, fillMode, fillValue) &
+                bind(C, name = "netcdfSetFillInt64")
+            import :: c_int
+            import :: c_long
+            import :: c_ptr
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: groupName
+            type(c_ptr), value, intent(in) :: varName
+            integer(c_int), value, intent(in) :: fillMode
+            integer(c_long), value, intent(in) :: fillValue
+            integer(c_int) :: c_netcdfSetFillInt64
+        end function c_netcdfSetFillInt64
+
+        ! See documentation for `c_netcdfSetFillInt`.
+        function c_netcdfSetFillReal(&
+                netcdfID, groupName, varName, fillMode, fillValue) &
+                bind(C, name = "netcdfSetFillReal")
+            import :: c_int
+            import :: c_ptr
+            import :: c_float
+            real(c_float), value, intent(in) :: fillValue
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: groupName
+            type(c_ptr), value, intent(in) :: varName
+            integer(c_int), value, intent(in) :: fillMode
+            integer(c_int) :: c_netcdfSetFillReal
+        end function c_netcdfSetFillReal
+
+        ! See documentation for `c_netcdfSetFillInt`.
+        function c_netcdfSetFillString(&
+                netcdfID, groupName, varName, fillMode, fillValue) &
+                bind(C, name = "netcdfSetFillString")
+            import :: c_int
+            import :: c_ptr
+            type(c_ptr), value, intent(in) :: fillValue
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: groupName
+            type(c_ptr), value, intent(in) :: varName
+            integer(c_int), value, intent(in) :: fillMode
+            integer(c_int) :: c_netcdfSetFillString
+        end function c_netcdfSetFillString
 
     end interface
 

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -1,7 +1,9 @@
 module netcdf_cxx_mod
-    use iso_c_binding, only : c_int, c_ptr, c_null_ptr
+    use iso_c_binding, only : c_int, c_ptr, c_null_ptr, c_loc, c_float, c_long
     use f_c_string_t_mod, only : f_c_string_t
-    use netcdf_cxx_i_mod, only : c_netcdfCreate, c_netcdfClose, c_netcdfAddGroup, c_netcdfAddDim
+    use f_c_string_1D_t_mod, only : f_c_string_1D_t
+    use netcdf_cxx_i_mod, only : c_netcdfCreate, c_netcdfClose, c_netcdfAddGroup, c_netcdfAddDim, &
+            c_netcdfAddVar, c_netcdfPutVarInt, c_netcdfPutVarInt64, c_netcdfPutVarReal, c_netcdfPutVarString
     use netcdf, only : NF90_INT, NF90_REAL
     implicit none
     public
@@ -134,5 +136,109 @@ contains
         netcdfAddDim = c_netcdfAddDim(netcdfID, c_groupName, c_dimName, len)
 
     end function netcdfAddDim
+
+    ! netcdfAddVar:
+    !   Adds a new variable to a NetCDF file, specifying its name, type, dimensions, and target group.
+    !
+    !   Arguments:
+    !     - netcdfID (integer(c_int), intent(in), value):
+    !       The identifier of the NetCDF file to which the variable will be added.
+    !     - varName (character(len=*), intent(in)):
+    !       The name of the new variable to be created.
+    !     - netcdfDataType (integer(c_int), intent(in), value):
+    !       The NetCDF data type of the variable (e.g., `NF90_INT`, `NF90_REAL`).
+    !     - numDims (integer(c_int), intent(in), value):
+    !       The number of dimensions associated with the variable.
+    !     - dimNames (character(len=*), dimension(numDims), intent(in)):
+    !       An array of dimension names that define the variable's shape.
+    !     - groupName (character(len=*), intent(in), optional):
+    !       The name of the group in which the variable will be created.
+    !       If not provided, the variable will be added as a global variable.
+    !
+    !   Returns:
+    !     - integer(c_int): A status code indicating the outcome of the operation:
+    !         - 0: Success.
+    !         - Non-zero: Failure.
+    function netcdfAddVar(netcdfID, varName, netcdfDataType, numDims, dimNames, groupName)
+        integer(c_int), value, intent(in) :: netcdfID
+        character(len = *), intent(in) :: varName
+        integer(c_int), value, intent(in) :: netcdfDataType
+        integer(c_int), value, intent(in) :: numDims
+        character(len = *), dimension(numDims), intent(in) :: dimNames
+        character(len = *), optional, intent(in) :: groupName
+        integer(c_int) :: netcdfAddVar
+        type(c_ptr) :: c_groupName
+        type(c_ptr) :: c_varName
+        type(c_ptr) :: c_dimNames
+        type(f_c_string_t) :: f_c_string_groupName
+        type(f_c_string_t) :: f_c_string_varName
+        type(f_c_string_1D_t) :: f_c_string_1D_dimNames
+
+        if (present(groupName)) then
+            c_groupName = f_c_string_groupName%to_c(groupName)
+        else
+            c_groupName = c_null_ptr
+        end if
+        c_varName = f_c_string_varName%to_c(varName)
+        c_dimNames = f_c_string_1D_dimNames%to_c(dimNames)
+        netcdfAddVar = c_netcdfAddVar(netcdfID, c_groupName, c_varName, &
+                netcdfDataType, numDims, c_dimNames)
+    end function netcdfAddVar
+
+    ! netcdfPutVar:
+    !   Writes data to a variable in a NetCDF file.
+    !
+    !   Arguments:
+    !     - netcdfID (integer(c_int), intent(in), value):
+    !       The identifier of the NetCDF file where the data will be written.
+    !     - varName (character(len=*), intent(in)):
+    !       The name of the variable to which data will be written.
+    !     - data (class(*), dimension(:), intent(in)):
+    !       The data to be written to the variable.
+    !     - groupName (character(len=*), intent(in), optional):
+    !       The name of the group containing the variable.
+    !       If not provided, the variable is assumed to be a global variable.
+    !
+    !   Returns:
+    !     - integer(c_int): A status code indicating the outcome of the operation:
+    !         - 0: Success.
+    !         - Non-zero: Failure.
+    function netcdfPutVar(netcdfID, varName, data, groupName)
+        integer(c_int), value, intent(in) :: netcdfID
+        character(len = *), intent(in) :: varName
+        class(*), dimension(:), intent(in) :: data
+        character(len = *), optional, intent(in) :: groupName
+        integer(c_int) :: netcdfPutVar
+        type(f_c_string_t) :: f_c_string_groupName
+        type(f_c_string_t) :: f_c_string_varName
+        type(c_ptr) :: c_groupName
+        type(c_ptr) :: c_varName
+        type(c_ptr) :: c_data
+        type(f_c_string_1D_t) :: f_c_string_1D_data
+
+        c_varName = f_c_string_varName%to_c(varName)
+
+        select type (data)
+        type is (integer(c_int))
+            c_data = c_loc(data)
+            netcdfPutVar = c_netcdfPutVarInt(netcdfID, c_groupName, &
+                    c_varName, c_data)
+
+        type is (integer(c_long))
+            c_data = c_loc(data)
+            netcdfPutVar = c_netcdfPutVarInt64(netcdfID, c_groupName, &
+                    c_varName, c_data)
+
+        type is (real(c_float))
+            c_data = c_loc(data)
+            netcdfPutVar = c_netcdfPutVarReal(netcdfID, c_groupName, &
+                    c_varName, c_data)
+
+        type is (character(len = *))
+            c_data = f_c_string_1D_data%to_c(data)
+            netcdfPutVar = c_netcdfPutVarString(netcdfID, c_groupName, &
+                    c_varName, c_data)
+        end select
+    end function netcdfPutVar
 
 end module netcdf_cxx_mod

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -193,7 +193,7 @@ contains
     !       The identifier of the NetCDF file where the data will be written.
     !     - varName (character(len=*), intent(in)):
     !       The name of the variable to which data will be written.
-    !     - data (class(*), dimension(:), intent(in)):
+    !     - values (class(*), dimension(:), intent(in)):
     !       The data to be written to the variable.
     !     - groupName (character(len=*), intent(in), optional):
     !       The name of the group containing the variable.
@@ -203,18 +203,18 @@ contains
     !     - integer(c_int): A status code indicating the outcome of the operation:
     !         - 0: Success.
     !         - Non-zero: Failure.
-    function netcdfPutVar(netcdfID, varName, data, groupName)
+    function netcdfPutVar(netcdfID, varName, values, groupName)
         integer(c_int), value, intent(in) :: netcdfID
         character(len = *), intent(in) :: varName
-        class(*), dimension(:), intent(in) :: data
+        class(*), dimension(:), intent(in) :: values
         character(len = *), optional, intent(in) :: groupName
         integer(c_int) :: netcdfPutVar
         type(f_c_string_t) :: f_c_string_groupName
         type(f_c_string_t) :: f_c_string_varName
         type(c_ptr) :: c_groupName
         type(c_ptr) :: c_varName
-        type(c_ptr) :: c_data
-        type(f_c_string_1D_t) :: f_c_string_1D_data
+        type(c_ptr) :: c_values
+        type(f_c_string_1D_t) :: f_c_string_1D_values
 
         if (present(groupName)) then
             c_groupName = f_c_string_groupName%to_c(groupName)
@@ -223,26 +223,26 @@ contains
         end if
         c_varName = f_c_string_varName%to_c(varName)
 
-        select type (data)
+        select type (values)
         type is (integer(c_int))
-            c_data = c_loc(data)
+            c_values = c_loc(values)
             netcdfPutVar = c_netcdfPutVarInt(netcdfID, c_groupName, &
-                    c_varName, c_data)
+                    c_varName, c_values)
 
         type is (integer(c_long))
-            c_data = c_loc(data)
+            c_values = c_loc(values)
             netcdfPutVar = c_netcdfPutVarInt64(netcdfID, c_groupName, &
-                    c_varName, c_data)
+                    c_varName, c_values)
 
         type is (real(c_float))
-            c_data = c_loc(data)
+            c_values = c_loc(values)
             netcdfPutVar = c_netcdfPutVarReal(netcdfID, c_groupName, &
-                    c_varName, c_data)
+                    c_varName, c_values)
 
         type is (character(len = *))
-            c_data = f_c_string_1D_data%to_c(data)
+            c_values = f_c_string_1D_values%to_c(values)
             netcdfPutVar = c_netcdfPutVarString(netcdfID, c_groupName, &
-                    c_varName, c_data)
+                    c_varName, c_values)
         end select
     end function netcdfPutVar
 

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -201,8 +201,10 @@ contains
     !
     !   Returns:
     !     - integer(c_int): A status code indicating the outcome of the operation:
-    !         - 0: Success.
-    !         - Non-zero: Failure.
+    !         -  0: Success.
+    !         - -1: NetCDF operation returned an error, but the error code was 0.
+    !         - -2: Unsupported type passed for values.
+    !         - Other nonzero values: Specific NetCDF error codes.
     function netcdfPutVar(netcdfID, varName, values, groupName)
         integer(c_int), value, intent(in) :: netcdfID
         character(len = *), intent(in) :: varName
@@ -243,6 +245,8 @@ contains
             c_values = f_c_string_1D_values%to_c(values)
             netcdfPutVar = c_netcdfPutVarString(netcdfID, c_groupName, &
                     c_varName, c_values)
+        class default
+            netcdfPutVar = -2
         end select
     end function netcdfPutVar
 
@@ -267,8 +271,10 @@ contains
     !
     !   Returns:
     !     - integer(c_int): A status code indicating the outcome of the operation:
-    !         - 0: Success.
-    !         - Non-zero: Failure.
+    !         -  0: Success.
+    !         - -1: NetCDF operation returned an error, but the error code was 0.
+    !         - -2: Unsupported type passed for fillValue.
+    !         - Other nonzero values: Specific NetCDF error codes.
     function netcdfSetFill(netcdfID, varName, fillMode, fillValue, groupName)
         integer(c_int), value, intent(in) :: netcdfID
         character(len = *), intent(in) :: varName
@@ -306,6 +312,8 @@ contains
             netcdfSetFill = c_netcdfSetFillString(netcdfID, c_groupName, &
                     c_varName, fillMode, &
                     f_c_string_fillValue%to_c(fillValue))
+        class default
+            netcdfSetFill = -2
         end select
     end function netcdfSetFill
 

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -1,5 +1,5 @@
 module netcdf_cxx_mod
-    use iso_c_binding, only : c_int, c_ptr, c_null_ptr, c_loc, c_float, c_long, c_f_pointer
+    use iso_c_binding, only : c_int, c_ptr, c_null_ptr, c_loc, c_float, c_long
     use f_c_string_t_mod, only : f_c_string_t
     use f_c_string_1D_t_mod, only : f_c_string_1D_t
     use netcdf_cxx_i_mod, only : c_netcdfCreate, c_netcdfClose, c_netcdfAddGroup, c_netcdfAddDim, &


### PR DESCRIPTION
### PR Description: Support for Creating and Setting NetCDF Variables in Fortran

#### **Description:**
This PR adds support for creating and writing variables in NetCDF files from Fortran using the NetCDF C++ API. It simplifies defining variables, specifying data types and dimensions, and writing data, handling both global and group-specific variables.

#### **Key Features:**
- **Variable Creation:** Supports defining variables with multiple dimensions in global or group contexts.
- **Data Writing:** Enables writing integer, real, and string data with automatic C/Fortran string conversion.
- **Fortran-Friendly Interface:** Abstracts low-level C++ API details, ensuring easy integration.

#### **Motivation:**
This enhancement provides a streamlined Fortran interface for NetCDF variable management, eliminating manual memory handling and C interoperability complexities.

