### PR TITLE
Import missing interface in netcdf_cxx_mod required for compilation.

### DIFF
--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -1,7 +1,7 @@
 module netcdf_cxx_mod
     use iso_c_binding, only : c_int, c_ptr, c_null_ptr
     use f_c_string_t_mod, only : f_c_string_t
-    use netcdf_cxx_i_mod, only : c_netcdfCreate, c_netcdfClose, c_netcdfAddGroup
+    use netcdf_cxx_i_mod, only : c_netcdfCreate, c_netcdfClose, c_netcdfAddGroup, c_netcdfAddDim
     use netcdf, only : NF90_INT, NF90_REAL
     implicit none
     public


### PR DESCRIPTION
An import statement was missing in netcdf_cxx_mod, which lead to an error when compiling the code in our current main branch. This PR fixes the bug.

TYPE: bug fix

TESTS CONDUCTED: successfully compiled code with mpas-jedi gnu environment.