### PR TITLE
Refactor gnssro observation processing module

### DIFF
--- a/obs2ioda-v2/src/gnssro_mod.f90
+++ b/obs2ioda-v2/src/gnssro_mod.f90
@@ -55,27 +55,15 @@ logical :: verbose = .false.
 contains
 
 subroutine read_write_gnssro(infile, outdir)
-!integer   :: nlev_dimid  ! seems to never be used
-!integer   :: varid_geo_temp,varid_geo_pres,varid_geo_shum,varid_geo_geop, varid_geo_geop_sfc  ! seems to never be used
-character(len=*), intent(in) :: infile
-character(len=*), intent(in) :: outdir
-character(len=10)         :: anatime
-!integer(i_kind)           :: nread  ! seems to never be used
-integer(i_kind) :: ndata, mincy, maxobs
-!logical                   :: outside  ! seems to never be used
-!real(r_kind) :: usage,dlat,dlat_earth,dlon,dlon_earth  ! seems to never be used
-
-call get_buffer_information(trim(adjustl(infile)), anatime, mincy, maxobs)
-
-call allocate_gnssro_data_array(maxobs)
-
-call read_gnssro_data(trim(adjustl(infile)), mincy, ndata)
-
-
-
-call write_gnssro_data(anatime, ndata, outdir)
-call deallocate_gnssro_data_array()
-
+   character(len = *), intent(in) :: infile
+   character(len = *), intent(in) :: outdir
+   character(len = 10) :: anatime
+   integer(i_kind) :: ndata, mincy, maxobs
+   call get_buffer_information(trim(adjustl(infile)), anatime, mincy, maxobs)
+   call allocate_gnssro_data_array(maxobs)
+   call read_gnssro_data(trim(adjustl(infile)), mincy, ndata)
+   call write_gnssro_data(anatime, ndata, outdir)
+   call deallocate_gnssro_data_array()
 end subroutine read_write_gnssro
 
 subroutine get_buffer_information(infile, anatime, mincy, maxobs)

--- a/obs2ioda-v2/src/gnssro_mod.f90
+++ b/obs2ioda-v2/src/gnssro_mod.f90
@@ -6,680 +6,675 @@
 !  Author: Hailing Zhang
 
 module gnssro_bufr2ioda
-use netcdf
-implicit none
-private
+   use netcdf
+   implicit none
+   private
+   public :: read_write_gnssro
 
-public :: read_write_gnssro
+   ! Type definitions. Note: we should eventually use the ones from the kinds module (whose names are not identical)
+   integer, parameter :: i_kind  = selected_int_kind(8)  ! 4
+   integer, parameter :: i_64    = selected_int_kind(10)  ! 8
+   integer, parameter :: r_kind  = selected_real_kind(15)  ! 8
+   real(r_kind), parameter :: r_missing = huge(1_i_kind)  ! perhaps this is a typo and should be huge(1.0_r_kind)?
+   integer(i_kind), parameter :: i_missing = huge(1_i_kind)
+   integer(i_64), parameter :: i64_missing = huge(1_i_64)
 
-integer, parameter :: i_kind  = selected_int_kind(8)    !4
-integer, parameter :: i_64    = selected_int_kind(10)   !8
-integer, parameter :: r_kind  = selected_real_kind(15)  !8
-real(r_kind), parameter :: r_missing = huge(1_i_kind)  ! perhaps this is a typo and should be huge(1.0_r_kind)?
-integer(i_kind), parameter :: i_missing = huge(1_i_kind)
-integer(i_64), parameter :: i64_missing = huge(1_i_64)
+   ! module parameters
+   integer(i_kind), parameter :: n1ahdr = 13, maxlevs = 500, datelength = 10, mxib = 31
+   character (*), parameter :: dateformat = '(i10.10)' ! the number of positions corresponds to datelength above 
+   character (*), parameter :: hdr1a = 'YEAR MNTH DAYS HOUR MINU PCCF ELRC SAID SIID PTID GEODU SCLF OGCE'
+   character (*), parameter :: nemo = 'QFRO'
+   logical, parameter :: verbose = .false.
 
-integer(i_kind), parameter :: n1ahdr = 13, maxlevs = 500, datelength = 10, mxib = 31
-character (*), parameter :: dateformat = '(i10.10)' ! the number of positions corresponds to datelength above 
-character (*), parameter :: hdr1a = 'YEAR MNTH DAYS HOUR MINU PCCF ELRC SAID SIID PTID GEODU SCLF OGCE'
-character (*), parameter :: nemo = 'QFRO'
-
-! output obs data stucture
-type gnssro_type
-      integer(i_kind), allocatable, dimension(:)    :: said
-      integer(i_kind), allocatable, dimension(:)    :: siid
-      integer(i_kind), allocatable, dimension(:)    :: sclf
-      integer(i_kind), allocatable, dimension(:)    :: ptid
-      integer(i_kind), allocatable, dimension(:)    :: recn
-      integer(i_kind), allocatable, dimension(:)    :: asce
-      integer(i_kind), allocatable, dimension(:)    :: ogce
-      real(r_kind), allocatable, dimension(:)       :: time
-      integer(i_64),allocatable, dimension(:)     :: epochtime
-      real(r_kind), allocatable, dimension(:)     :: lat
-      real(r_kind), allocatable, dimension(:)     :: lon
-      real(r_kind), allocatable, dimension(:)     :: rfict
-      real(r_kind), allocatable, dimension(:)     :: azim
-      real(r_kind), allocatable, dimension(:)     :: geoid
-      real(r_kind), allocatable, dimension(:)     :: msl_alt
-      real(r_kind), allocatable, dimension(:)     :: ref
-      real(r_kind), allocatable, dimension(:)     :: refoe_gsi
-      real(r_kind), allocatable, dimension(:)     :: bend_ang
-      real(r_kind), allocatable, dimension(:)     :: impact_para
-      real(r_kind), allocatable, dimension(:)     :: bndoe_gsi
-end type gnssro_type
-
-type(gnssro_type) :: gnssro_data
-
-logical :: verbose = .false.
+   ! output obs data stucture
+   type gnssro_type
+      integer(i_kind), allocatable, dimension(:) :: said
+      integer(i_kind), allocatable, dimension(:) :: siid
+      integer(i_kind), allocatable, dimension(:) :: sclf
+      integer(i_kind), allocatable, dimension(:) :: ptid
+      integer(i_kind), allocatable, dimension(:) :: recn
+      integer(i_kind), allocatable, dimension(:) :: asce
+      integer(i_kind), allocatable, dimension(:) :: ogce
+      real(r_kind), allocatable, dimension(:) :: time
+      integer(i_64),allocatable, dimension(:) :: epochtime
+      real(r_kind), allocatable, dimension(:) :: lat
+      real(r_kind), allocatable, dimension(:) :: lon
+      real(r_kind), allocatable, dimension(:) :: rfict
+      real(r_kind), allocatable, dimension(:) :: azim
+      real(r_kind), allocatable, dimension(:) :: geoid
+      real(r_kind), allocatable, dimension(:) :: msl_alt
+      real(r_kind), allocatable, dimension(:) :: ref
+      real(r_kind), allocatable, dimension(:) :: refoe_gsi
+      real(r_kind), allocatable, dimension(:) :: bend_ang
+      real(r_kind), allocatable, dimension(:) :: impact_para
+      real(r_kind), allocatable, dimension(:) :: bndoe_gsi
+   end type gnssro_type
+   type(gnssro_type) :: gnssro_data
 
 contains
 
-subroutine read_write_gnssro(infile, outdir)
-   character(len = *), intent(in) :: infile
-   character(len = *), intent(in) :: outdir
-   character(len = 10) :: anatime
-   integer(i_kind) :: ndata, mincy, maxobs
-   call get_buffer_information(trim(adjustl(infile)), anatime, mincy, maxobs)
-   call allocate_gnssro_data_array(maxobs)
-   call read_gnssro_data(trim(adjustl(infile)), mincy, ndata)
-   call write_gnssro_data(anatime, ndata, outdir)
-   call deallocate_gnssro_data_array()
-end subroutine read_write_gnssro
-
-subroutine get_buffer_information(infile, anatime, mincy, maxobs)
-   character(len = *), intent(in) :: infile
-   character(len = *), intent(out) :: anatime
-   integer(i_kind), intent(out) :: mincy, maxobs
-   integer(i_kind), parameter :: lnbufr = 10  ! the bufr library expects a unit number in [0-99] -> can't use newunit
-   character(len = 8) :: subset
-   integer(i_kind) :: idate, iret, levs
-   integer, dimension(6) :: iadate5
-   integer(i_kind) :: ireadmg, ireadsb
-   real(r_kind), dimension(n1ahdr) :: bfr1ahdr
-   real(r_kind), dimension(50, maxlevs) :: data1b
-   ! open file and connect to buffer library
-   open(unit = lnbufr, file = infile, form = 'unformatted')
-   call openbf(lnbufr, 'IN', lnbufr)
-   call datelen(datelength)
-   ! obtain analysis time
-   call readmg(lnbufr, subset, idate, iret)
-   if (iret /= 0) then
-      write(6, *) 'READ_GNSSRO: can not open gnssro file!'
-      stop
-   end if
-   write(*, fmt = '(a,i10)') infile // ' file date is: ', idate
-   iadate5(1) = idate / 1000000
-   iadate5(2) = (idate - iadate5(1) * 1000000) / 10000
-   iadate5(3) = (idate - iadate5(1) * 1000000 - iadate5(2) * 10000) / 100
-   iadate5(4) = idate - iadate5(1) * 1000000 - iadate5(2) * 10000 - iadate5(3) * 100
-   iadate5(5) = 0
-   call w3fs21(iadate5, mincy)
-   write(anatime, dateformat) idate
-   ! estimate total number of observations
-   maxobs = 0
-   do while (ireadmg(lnbufr, subset, idate) == 0)
-      do while(ireadsb(lnbufr) == 0)
-         call ufbint(lnbufr, bfr1ahdr, n1ahdr, 1, iret, hdr1a)
-         call ufbseq(lnbufr, data1b, 50, maxlevs, levs, 'ROSEQ1')
-         maxobs = maxobs + levs
-      enddo
-   end do
-   call closbf(lnbufr)  ! this also closes the frotran file unit
-end subroutine
+   subroutine read_write_gnssro(infile, outdir)
+      character(len = *), intent(in) :: infile
+      character(len = *), intent(in) :: outdir
+      character(len = 10) :: anatime
+      integer(i_kind) :: ndata, mincy, maxobs
+      call get_buffer_information(trim(adjustl(infile)), anatime, mincy, maxobs)
+      call allocate_gnssro_data_array(maxobs)
+      call read_gnssro_data(trim(adjustl(infile)), mincy, ndata)
+      call write_gnssro_data(anatime, ndata, outdir)
+      call deallocate_gnssro_data_array()
+   end subroutine read_write_gnssro
 
 
-subroutine allocate_gnssro_data_array(maxobs)
-   integer, intent(in) :: maxobs
-   allocate(gnssro_data%said(maxobs))
-   allocate(gnssro_data%siid(maxobs))
-   allocate(gnssro_data%sclf(maxobs))
-   allocate(gnssro_data%ptid(maxobs))
-   allocate(gnssro_data%recn(maxobs))
-   allocate(gnssro_data%asce(maxobs))
-   allocate(gnssro_data%ogce(maxobs))
-   allocate(gnssro_data%time(maxobs))
-   allocate(gnssro_data%epochtime(maxobs))
-   allocate(gnssro_data%lat(maxobs))
-   allocate(gnssro_data%lon(maxobs))
-   allocate(gnssro_data%rfict(maxobs))
-   allocate(gnssro_data%azim(maxobs))
-   allocate(gnssro_data%geoid(maxobs))
-   allocate(gnssro_data%msl_alt(maxobs))
-   allocate(gnssro_data%ref(maxobs))
-   allocate(gnssro_data%refoe_gsi(maxobs))
-   allocate(gnssro_data%bend_ang(maxobs))
-   allocate(gnssro_data%impact_para(maxobs))
-   allocate(gnssro_data%bndoe_gsi(maxobs))
-end subroutine
+   subroutine get_buffer_information(infile, anatime, mincy, maxobs)
+      character(len = *), intent(in) :: infile
+      character(len = *), intent(out) :: anatime
+      integer(i_kind), intent(out) :: mincy, maxobs
+      integer(i_kind), parameter :: lnbufr = 10  ! the bufr library expects a unit number in [0-99] -> can't use newunit
+      character(len = 8) :: subset
+      integer(i_kind) :: idate, iret, levs
+      integer, dimension(6) :: iadate5
+      integer(i_kind) :: ireadmg, ireadsb
+      real(r_kind), dimension(n1ahdr) :: bfr1ahdr
+      real(r_kind), dimension(50, maxlevs) :: data1b
+      ! open file and connect to buffer library
+      open(unit = lnbufr, file = infile, form = 'unformatted')
+      call openbf(lnbufr, 'IN', lnbufr)
+      call datelen(datelength)
+      ! obtain analysis time
+      call readmg(lnbufr, subset, idate, iret)
+      if (iret /= 0) then
+         write(6, *) 'READ_GNSSRO: can not open gnssro file!'
+         stop
+      end if
+      write(*, fmt = '(a,i10)') infile // ' file date is: ', idate
+      iadate5(1) = idate / 1000000
+      iadate5(2) = (idate - iadate5(1) * 1000000) / 10000
+      iadate5(3) = (idate - iadate5(1) * 1000000 - iadate5(2) * 10000) / 100
+      iadate5(4) = idate - iadate5(1) * 1000000 - iadate5(2) * 10000 - iadate5(3) * 100
+      iadate5(5) = 0
+      call w3fs21(iadate5, mincy)
+      write(anatime, dateformat) idate
+      ! estimate total number of observations
+      maxobs = 0
+      do while (ireadmg(lnbufr, subset, idate) == 0)
+         do while(ireadsb(lnbufr) == 0)
+            call ufbint(lnbufr, bfr1ahdr, n1ahdr, 1, iret, hdr1a)
+            call ufbseq(lnbufr, data1b, 50, maxlevs, levs, 'ROSEQ1')
+            maxobs = maxobs + levs
+         enddo
+      end do
+      call closbf(lnbufr)  ! this also closes the frotran file unit
+   end subroutine
 
-subroutine read_gnssro_data(infile, mincy, ndata)
-   character(len = *), intent(in) :: infile
-   integer(i_kind), intent(in) :: mincy
-   integer(i_kind), intent(out) :: ndata
-   integer(i_kind), parameter :: lnbufr = 10
-   character(len = 8) :: subset
-   integer(i_kind) :: idate, iret
-   integer(i_kind) :: ireadmg, ireadsb
-   real(r_kind), dimension(n1ahdr) :: bfr1ahdr
-   real(r_kind), dimension(1) :: qfro
-   integer(i_kind), dimension(6) :: idate5
-   real(r_kind) :: pcc, roc, geoid, timeo
-   integer(i_kind) :: said, siid, ptid, sclf, ogce, minobs, nib, asce
-   integer(i_64) :: epochtime
-   integer :: refflag, bendflag
-   integer(i_kind), dimension(mxib) :: ibit
-   integer(i_kind) :: i, k, m
-   real(r_kind), dimension(maxlevs) :: nreps_this_ROSEQ2
-   integer(i_kind) :: nreps_ROSEQ1, levs, levsr, nrec, ndata0, nreps_ROSEQ2_int
-   real(r_kind), dimension(50, maxlevs) :: data1b, data2a
-   real(r_kind)  :: rlat, rlon, azim, height, ref, ref_error, ref_pccf
-   real(r_kind) :: freq_chk, freq, impact, bend, bend_error, bend_pccf, obsErr
-   logical :: good
-   logical, parameter :: GlobalModel = .true.  ! temporary
 
-   ndata = 0  ! initialize
-   nrec = 0
+   subroutine allocate_gnssro_data_array(maxobs)
+      integer, intent(in) :: maxobs
+      allocate(gnssro_data%said(maxobs))
+      allocate(gnssro_data%siid(maxobs))
+      allocate(gnssro_data%sclf(maxobs))
+      allocate(gnssro_data%ptid(maxobs))
+      allocate(gnssro_data%recn(maxobs))
+      allocate(gnssro_data%asce(maxobs))
+      allocate(gnssro_data%ogce(maxobs))
+      allocate(gnssro_data%time(maxobs))
+      allocate(gnssro_data%epochtime(maxobs))
+      allocate(gnssro_data%lat(maxobs))
+      allocate(gnssro_data%lon(maxobs))
+      allocate(gnssro_data%rfict(maxobs))
+      allocate(gnssro_data%azim(maxobs))
+      allocate(gnssro_data%geoid(maxobs))
+      allocate(gnssro_data%msl_alt(maxobs))
+      allocate(gnssro_data%ref(maxobs))
+      allocate(gnssro_data%refoe_gsi(maxobs))
+      allocate(gnssro_data%bend_ang(maxobs))
+      allocate(gnssro_data%impact_para(maxobs))
+      allocate(gnssro_data%bndoe_gsi(maxobs))
+   end subroutine
 
-   ! open file and attach buffer library to it
-   open(unit = lnbufr, file = infile, form = 'unformatted')
-   call openbf(lnbufr, 'IN', lnbufr)
-   call datelen(datelength)
-   call readmg(lnbufr, subset, idate, iret)
-   ! read data
-   do while(ireadmg(lnbufr, subset, idate) == 0)
-      read_loop:  do while(ireadsb(lnbufr) == 0)
-         ! Read / decode data in subset (profile)
-         call ufbint(lnbufr, bfr1ahdr, n1ahdr, 1, iret, hdr1a)
-         call ufbint(lnbufr, qfro, 1, 1, iret, nemo)
-         ! observation time in minutes
-         idate5(1) = bfr1ahdr(1)  ! year
-         idate5(2) = bfr1ahdr(2)  ! month
-         idate5(3) = bfr1ahdr(3)  ! day
-         idate5(4) = bfr1ahdr(4)  ! hour
-         idate5(5) = bfr1ahdr(5)  ! minute
-         idate5(6) = 0  ! seconds
-         pcc  = bfr1ahdr(6)  ! profile per cent confidence
-         roc  = bfr1ahdr(7)  ! Earth local radius of curvature
-         said = bfr1ahdr(8)  ! Satellite identifier
-         siid = bfr1ahdr(9)  ! Satellite instrument
-         ptid = bfr1ahdr(10)  ! Platform transmitter ID number
-         geoid= bfr1ahdr(11)  ! Geoid undulation
-         sclf = bfr1ahdr(12)  ! Satellite classification
-         ogce = bfr1ahdr(13)  ! Identification of originating/generating centre
-         call w3fs21(idate5, minobs)
-         timeo = real(minobs - mincy, r_kind) / 60.0
-         call epochtimecalculator(idate5, epochtime)  ! calculate epochtime since January 1 1970
-         ! check if values are in valid range
-         ! earth radius of curvature
-         if (roc > 6450000.0_r_kind .or. roc < 6250000.0_r_kind .or. geoid > 200_r_kind .or. geoid < -200._r_kind) then
-            if (verbose) write(6, *) 'READ_GNSSRO: profile fails georeality check, skip this report'
-            cycle read_loop
-         endif
-         ! profile check: (1) CDAAC processing - cosmic-1, cosmic-2, sacc, cnofs, kompsat5
-         if (((said >= 740) .and. (said <= 745)) .or. ((said >= 750) .and. (said <= 755)) &
-            .or. (said == 820) .or. (said == 786) .or. (said == 825) .or. ogce == 60) then  !CDAAC processing
-            if(pcc == 0.0) then
-               if (verbose) write(6, *) 'READ_GNSSRO: bad profile 0.0% confidence said=', said,'ptid=',ptid, ' SKIP this report'
+
+   subroutine read_gnssro_data(infile, mincy, ndata)
+      character(len = *), intent(in) :: infile
+      integer(i_kind), intent(in) :: mincy
+      integer(i_kind), intent(out) :: ndata
+      integer(i_kind), parameter :: lnbufr = 10
+      character(len = 8) :: subset
+      integer(i_kind) :: idate, iret
+      integer(i_kind) :: ireadmg, ireadsb
+      real(r_kind), dimension(n1ahdr) :: bfr1ahdr
+      real(r_kind), dimension(1) :: qfro
+      integer(i_kind), dimension(6) :: idate5
+      real(r_kind) :: pcc, roc, geoid, timeo
+      integer(i_kind) :: said, siid, ptid, sclf, ogce, minobs, nib, asce
+      integer(i_64) :: epochtime
+      integer :: refflag, bendflag
+      integer(i_kind), dimension(mxib) :: ibit
+      integer(i_kind) :: i, k, m
+      real(r_kind), dimension(maxlevs) :: nreps_this_ROSEQ2
+      integer(i_kind) :: nreps_ROSEQ1, levs, levsr, nrec, ndata0, nreps_ROSEQ2_int
+      real(r_kind), dimension(50, maxlevs) :: data1b, data2a
+      real(r_kind)  :: rlat, rlon, azim, height, ref, ref_error, ref_pccf
+      real(r_kind) :: freq_chk, freq, impact, bend, bend_error, bend_pccf, obsErr
+      logical :: good
+      logical, parameter :: GlobalModel = .true.  ! temporary
+
+      ! initialize counters
+      ndata = 0
+      nrec = 0
+      ! open file and attach buffer library to it
+      open(unit = lnbufr, file = infile, form = 'unformatted')
+      call openbf(lnbufr, 'IN', lnbufr)
+      call datelen(datelength)
+      call readmg(lnbufr, subset, idate, iret)
+      ! read data
+      do while(ireadmg(lnbufr, subset, idate) == 0)
+         read_loop:  do while(ireadsb(lnbufr) == 0)
+            ! Read / decode data in subset (profile)
+            call ufbint(lnbufr, bfr1ahdr, n1ahdr, 1, iret, hdr1a)
+            call ufbint(lnbufr, qfro, 1, 1, iret, nemo)
+            ! observation time in minutes
+            idate5(1) = bfr1ahdr(1)  ! year
+            idate5(2) = bfr1ahdr(2)  ! month
+            idate5(3) = bfr1ahdr(3)  ! day
+            idate5(4) = bfr1ahdr(4)  ! hour
+            idate5(5) = bfr1ahdr(5)  ! minute
+            idate5(6) = 0  ! seconds
+            pcc  = bfr1ahdr(6)  ! profile per cent confidence
+            roc  = bfr1ahdr(7)  ! Earth local radius of curvature
+            said = bfr1ahdr(8)  ! Satellite identifier
+            siid = bfr1ahdr(9)  ! Satellite instrument
+            ptid = bfr1ahdr(10)  ! Platform transmitter ID number
+            geoid= bfr1ahdr(11)  ! Geoid undulation
+            sclf = bfr1ahdr(12)  ! Satellite classification
+            ogce = bfr1ahdr(13)  ! Identification of originating/generating centre
+            call w3fs21(idate5, minobs)
+            timeo = real(minobs - mincy, r_kind) / 60.0
+            call epochtimecalculator(idate5, epochtime)  ! calculate epochtime since January 1 1970
+            ! check if values are in valid range
+            ! earth radius of curvature
+            if (roc > 6450000.0_r_kind .or. roc < 6250000.0_r_kind .or. geoid > 200_r_kind .or. geoid < -200._r_kind) then
+               if (verbose) write(6, *) 'READ_GNSSRO: profile fails georeality check, skip this report'
                cycle read_loop
             endif
-         endif
-         ! profile check: (2) GRAS SAF processing - metopa-c, oceansat2, megha-tropiques, sacd 
-         bendflag = 0
-         refflag  = 0
-         if ((said >= 3 .and. said <= 5) .or. (said == 421) .or. (said == 440) .or. (said == 821)) then 
+            ! profile check: (1) CDAAC processing - cosmic-1, cosmic-2, sacc, cnofs, kompsat5
+            if (((said >= 740) .and. (said <= 745)) .or. ((said >= 750) .and. (said <= 755)) &
+               .or. (said == 820) .or. (said == 786) .or. (said == 825) .or. ogce == 60) then  !CDAAC processing
+               if(pcc == 0.0) then
+                  if (verbose) write(6, *) 'READ_GNSSRO: bad profile 0.0% confidence said=', said, 'ptid=', ptid, &
+                     ' SKIP this report'
+                  cycle read_loop
+               endif
+            endif
+            ! profile check: (2) GRAS SAF processing - metopa-c, oceansat2, megha-tropiques, sacd 
+            bendflag = 0
+            refflag  = 0
+            if ((said >= 3 .and. said <= 5) .or. (said == 421) .or. (said == 440) .or. (said == 821)) then 
+               call upftbv(lnbufr, nemo, qfro, mxib, ibit, nib)
+               if(nib > 0) then
+                  do i = 1, nib
+                     if(ibit(i) == 5) then  ! bending angle
+                        bendflag = 1
+                        if (verbose) write(6, *) 'READ_GNSSRO: bad profile said=', said, 'ptid=', ptid, ' SKIP this report'
+                        cycle read_loop
+                     endif
+                     if(ibit(i)== 6) then  ! refractivity
+                        refflag = 1
+                        exit
+                     endif
+                  enddo
+               endif 
+            endif
+            ! check associated with ascending flag
+            asce = 0
             call upftbv(lnbufr, nemo, qfro, mxib, ibit, nib)
-            if(nib > 0) then
+            if (nib > 0) then
                do i = 1, nib
-                  if(ibit(i) == 5) then  ! bending angle
-                     bendflag = 1
-                     if (verbose) write(6, *) 'READ_GNSSRO: bad profile said=', said, 'ptid=', ptid, ' SKIP this report'
-                     cycle read_loop
-                  endif
-                  if(ibit(i)== 6) then  ! refractivity
-                     refflag = 1
+                  if(ibit(i) == 3) then
+                     asce = 1
                      exit
                   endif
                enddo
-            endif 
-         endif
-         ! check associated with ascending flag
-         asce = 0
-         call upftbv(lnbufr, nemo, qfro, mxib, ibit, nib)
-         if (nib > 0) then
-            do i = 1, nib
-               if(ibit(i) == 3) then
-                  asce = 1
-                  exit
-               endif
-            enddo
-         end if
-         ! read further data
-         call ufbint(lnbufr, nreps_this_ROSEQ2, 1, maxlevs, nreps_ROSEQ1, '{ROSEQ2}')
-         call ufbseq(lnbufr, data1b, 50, maxlevs,levs, 'ROSEQ1') 
-         call ufbseq(lnbufr, data2a, 50, maxlevs, levsr, 'ROSEQ3') ! refractivity
-         nrec = nrec + 1
-         ndata0 = ndata
-         do k = 1, levs
-            rlat = data1b(1, k)  ! earth relative latitude (degrees)
-            rlon = data1b(2, k)  ! earth relative longitude (degrees)
-            azim = data1b(3, k)
-            height = data2a(1, k)
-            ref = data2a(2, k)
-            ref_error = data2a(4, k)
-            ref_pccf = data2a(6, k)
-            ! Loop over number of replications of ROSEQ2 nested inside this particular replication of ROSEQ1
-            nreps_ROSEQ2_int = nreps_this_ROSEQ2(k)
-            do i = 1, nreps_ROSEQ2_int
-               m = (6 * i) - 2
-               freq_chk = data1b(m, k) ! frequency (hertz)
-               if(nint(freq_chk) .ne. 0) cycle ! do not want non-zero freq., go on to next replication of ROSEQ2
-               freq = data1b(m, k)
-               impact = data1b(m + 1, k)  ! impact parameter (m)
-               bend = data1b(m + 2, k)  ! bending angle (rad)
-               bend_error = data1b(m + 4, k)  ! RMSE in bending angle (rad)
-            enddo
-            bend_pccf = data1b((6 * nreps_ROSEQ2_int) + 4, k)  ! percent confidence for this ROSEQ1 replication
-            ! check if newly read quantities are in valid range
-            ! height and latitude / longitude
-            good = .true. 
-            if (height < 0._r_kind .or. height > 100000._r_kind .or. abs(rlat) > 90._r_kind .or. abs(rlon) > 360._r_kind) then
-               good = .false.
-               if (verbose) write(6, *) 'READ_GNSSRO: obs fails georeality check, said=', said, 'ptid=', ptid
-            endif
-            ! bending angle and impact parameter
-            if (bend >= 1.e+9_r_kind .or. bend <= 0._r_kind .or. impact >= 1.e+9_r_kind .or. impact < roc .or. bendflag == 1 ) then
-               good = .false.
-               if (verbose) write(6, *) 'READ_GNSSRO: obs bend/impact is invalid, said=', said, 'ptid=', ptid
-            endif
-            ! reffractivity
-            if (ref >= 1.e+9_r_kind .or. ref <= 0._r_kind .or. refflag == 1 ) then
-             ref = r_missing
-            endif
-            ! azimuth
-            if (abs(azim) > 360._r_kind .or. azim < 0._r_kind) then
-               azim = r_missing
-            endif
-            ! append data if values are in valid range
-            if (good) then
-               ndata = ndata + 1 
-               gnssro_data%recn(ndata) = nrec
-               gnssro_data%lat(ndata) = rlat
-               gnssro_data%lon(ndata) = rlon
-               gnssro_data%time(ndata) = timeo
-               gnssro_data%epochtime(ndata) = epochtime
-               gnssro_data%said(ndata) = said
-               gnssro_data%siid(ndata) = siid
-               gnssro_data%sclf(ndata) = sclf
-               gnssro_data%asce(ndata) = asce
-               gnssro_data%ptid(ndata) = ptid
-               gnssro_data%ogce(ndata) = ogce
-               gnssro_data%ref(ndata) = ref
-               gnssro_data%msl_alt(ndata) = height
-               gnssro_data%bend_ang(ndata) = bend
-               gnssro_data%bndoe_gsi(ndata) = bend_error
-               gnssro_data%impact_para(ndata) = impact
-               gnssro_data%rfict(ndata) = roc
-               gnssro_data%geoid(ndata) = geoid
-               gnssro_data%azim(ndata) = azim
-               call bendingangle_err_gsi(rlat, impact - roc, obsErr, ogce, said)
-               gnssro_data%bndoe_gsi(ndata) = obsErr
-               if (ref > r_missing)  then
-                  call refractivity_err_gsi(rlat, height, GlobalModel, obsErr)
-                  gnssro_data%refoe_gsi(ndata) = obsErr
-               else
-                  gnssro_data%refoe_gsi(ndata) = r_missing
-               end if
             end if
-         end do ! end of k loop
-         if (ndata == ndata0) nrec = nrec - 1
-      enddo read_loop
-   end do
-   call closbf(lnbufr)
-   if (nrec == 0) then
-      write(6, *) "Error. No valid observations found. Cannot create NetCDF ouput."
-      stop 2
-   endif
-end subroutine
+            ! read further data
+            call ufbint(lnbufr, nreps_this_ROSEQ2, 1, maxlevs, nreps_ROSEQ1, '{ROSEQ2}')
+            call ufbseq(lnbufr, data1b, 50, maxlevs,levs, 'ROSEQ1') 
+            call ufbseq(lnbufr, data2a, 50, maxlevs, levsr, 'ROSEQ3') ! refractivity
+            nrec = nrec + 1
+            ndata0 = ndata
+            do k = 1, levs
+               rlat = data1b(1, k)  ! earth relative latitude (degrees)
+               rlon = data1b(2, k)  ! earth relative longitude (degrees)
+               azim = data1b(3, k)
+               height = data2a(1, k)
+               ref = data2a(2, k)
+               ref_error = data2a(4, k)
+               ref_pccf = data2a(6, k)
+               ! Loop over number of replications of ROSEQ2 nested inside this particular replication of ROSEQ1
+               nreps_ROSEQ2_int = nreps_this_ROSEQ2(k)
+               do i = 1, nreps_ROSEQ2_int
+                  m = (6 * i) - 2
+                  freq_chk = data1b(m, k) ! frequency (hertz)
+                  if(nint(freq_chk) .ne. 0) cycle ! do not want non-zero freq., go on to next replication of ROSEQ2
+                  freq = data1b(m, k)
+                  impact = data1b(m + 1, k)  ! impact parameter (m)
+                  bend = data1b(m + 2, k)  ! bending angle (rad)
+                  bend_error = data1b(m + 4, k)  ! RMSE in bending angle (rad)
+               enddo
+               bend_pccf = data1b((6 * nreps_ROSEQ2_int) + 4, k)  ! percent confidence for this ROSEQ1 replication
+               ! check if newly read quantities are in valid range
+               ! height and latitude / longitude
+               good = .true. 
+               if (height < 0._r_kind .or. height > 100000._r_kind .or. abs(rlat) > 90._r_kind .or. &
+                  abs(rlon) > 360._r_kind) then
+                  good = .false.
+                  if (verbose) write(6, *) 'READ_GNSSRO: obs fails georeality check, said=', said, 'ptid=', ptid
+               endif
+               ! bending angle and impact parameter
+               if (bend >= 1.e+9_r_kind .or. bend <= 0._r_kind .or. impact >= 1.e+9_r_kind .or. impact < roc .or. &
+                  bendflag == 1 ) then
+                  good = .false.
+                  if (verbose) write(6, *) 'READ_GNSSRO: obs bend/impact is invalid, said=', said, 'ptid=', ptid
+               endif
+               ! reffractivity
+               if (ref >= 1.e+9_r_kind .or. ref <= 0._r_kind .or. refflag == 1 ) then
+               ref = r_missing
+               endif
+               ! azimuth
+               if (abs(azim) > 360._r_kind .or. azim < 0._r_kind) then
+                  azim = r_missing
+               endif
+               ! append data if values are in valid range
+               if (good) then
+                  ndata = ndata + 1 
+                  gnssro_data%recn(ndata) = nrec
+                  gnssro_data%lat(ndata) = rlat
+                  gnssro_data%lon(ndata) = rlon
+                  gnssro_data%time(ndata) = timeo
+                  gnssro_data%epochtime(ndata) = epochtime
+                  gnssro_data%said(ndata) = said
+                  gnssro_data%siid(ndata) = siid
+                  gnssro_data%sclf(ndata) = sclf
+                  gnssro_data%asce(ndata) = asce
+                  gnssro_data%ptid(ndata) = ptid
+                  gnssro_data%ogce(ndata) = ogce
+                  gnssro_data%ref(ndata) = ref
+                  gnssro_data%msl_alt(ndata) = height
+                  gnssro_data%bend_ang(ndata) = bend
+                  gnssro_data%bndoe_gsi(ndata) = bend_error
+                  gnssro_data%impact_para(ndata) = impact
+                  gnssro_data%rfict(ndata) = roc
+                  gnssro_data%geoid(ndata) = geoid
+                  gnssro_data%azim(ndata) = azim
+                  call bendingangle_err_gsi(rlat, impact - roc, obsErr, ogce, said)
+                  gnssro_data%bndoe_gsi(ndata) = obsErr
+                  if (ref > r_missing)  then
+                     call refractivity_err_gsi(rlat, height, GlobalModel, obsErr)
+                     gnssro_data%refoe_gsi(ndata) = obsErr
+                  else
+                     gnssro_data%refoe_gsi(ndata) = r_missing
+                  end if
+               end if
+            end do ! end of k loop
+            if (ndata == ndata0) nrec = nrec - 1
+         enddo read_loop
+      end do
+      call closbf(lnbufr)
+      if (nrec == 0) then
+         write(6, *) "Error. No valid observations found. Cannot create NetCDF ouput."
+         stop 2
+      endif
+   end subroutine
 
-subroutine write_gnssro_data(anatime, ndata, outdir)
-   character(len = *), intent(in) :: anatime, outdir
-   integer(i_kind), intent(in) :: ndata
-   character(len = datelength) :: cdate
-   character (:), allocatable :: outfile
-   integer :: ncid, nlocs_dimid, grpid_metadata, grpid_obsvalue, grpid_obserror
-   integer :: varid_lat, varid_lon, varid_time, varid_epochtime, varid_recn, varid_sclf, varid_ptid, varid_said
-   integer :: varid_siid, varid_asce, varid_ogce, varid_msl, varid_impp, varid_imph, varid_azim, varid_geoid, varid_rfict
-   integer :: varid_ref, varid_refoe, varid_bnd, varid_bndoe
 
-   ! create netcdf file and enter define mode
-   outfile = trim(adjustl(outdir)) // 'gnssro_obs_' // anatime // '.h5'
-   call check(nf90_create(outfile, NF90_NETCDF4, ncid))
+   subroutine write_gnssro_data(anatime, ndata, outdir)
+      character(len = *), intent(in) :: anatime, outdir
+      integer(i_kind), intent(in) :: ndata
+      character(len = datelength) :: cdate
+      character (:), allocatable :: outfile
+      integer :: ncid, nlocs_dimid, grpid_metadata, grpid_obsvalue, grpid_obserror
+      integer :: varid_lat, varid_lon, varid_time, varid_epochtime, varid_recn, varid_sclf, varid_ptid, varid_said
+      integer :: varid_siid, varid_asce, varid_ogce, varid_msl, varid_impp, varid_imph, varid_azim, varid_geoid, varid_rfict
+      integer :: varid_ref, varid_refoe, varid_bnd, varid_bndoe
 
-   ! create dimensions
-   call check(nf90_def_dim(ncid, 'nlocs', ndata, nlocs_dimid))
+      ! create netcdf file and enter define mode
+      outfile = trim(adjustl(outdir)) // 'gnssro_obs_' // anatime // '.h5'
+      call check(nf90_create(outfile, NF90_NETCDF4, ncid))
 
-   ! write global attributes
-   call check(nf90_put_att(ncid, NF90_GLOBAL, 'date_time', anatime))
-   call check(nf90_put_att(ncid, NF90_GLOBAL, 'ioda_version', 'fortran generated ioda2 file'))
+      ! create dimensions
+      call check(nf90_def_dim(ncid, 'nlocs', ndata, nlocs_dimid))
 
-   ! create groups
-   call check(nf90_def_grp(ncid, 'MetaData', grpid_metadata))
-   call check(nf90_def_grp(ncid, 'ObsValue', grpid_obsvalue))
-   call check(nf90_def_grp(ncid, 'ObsError', grpid_obserror))
+      ! write global attributes
+      call check(nf90_put_att(ncid, NF90_GLOBAL, 'date_time', anatime))
+      call check(nf90_put_att(ncid, NF90_GLOBAL, 'ioda_version', 'fortran generated ioda2 file'))
 
-   ! create variables, write their attributes and fill value
-   ! MetaData/latitude
-   call check(nf90_def_var(grpid_metadata, "latitude", NF90_FLOAT, nlocs_dimid, varid_lat))
-   call check(nf90_put_att(grpid_metadata, varid_lat, "units", "degree_north"))
-   call check(nf90_def_var_fill(grpid_metadata, varid_lat, 0, real(r_missing)))
-   ! MetaData/longitude
-   call check(nf90_def_var(grpid_metadata, "longitude", NF90_FLOAT, nlocs_dimid, varid_lon))
-   call check(nf90_put_att(grpid_metadata, varid_lon, "units", "degree_east"))
-   call check(nf90_def_var_fill(grpid_metadata, varid_lon, 0, real(r_missing)))
-   ! MetaData/time
-   call check(nf90_def_var(grpid_metadata, "time", NF90_FLOAT, nlocs_dimid, varid_time))
-   call check(nf90_put_att(grpid_metadata, varid_time, "longname", "time offset to analysis time"))
-   call check(nf90_put_att(grpid_metadata, varid_time, "units", "hour"))
-   call check(nf90_def_var_fill(grpid_metadata, varid_time, 0, real(r_missing)))
-   ! MetaData/dateTime
-   call check(nf90_def_var(grpid_metadata, "dateTime", NF90_INT64, nlocs_dimid, varid_epochtime))
-   call check(nf90_put_att(grpid_metadata, varid_epochtime, "units", "seconds since 1970-01-01T00:00:00Z"))
-   call check(nf90_def_var_fill(grpid_metadata, varid_epochtime, 0, i64_missing))
-   ! MetaData/record_number
-   call check(nf90_def_var(grpid_metadata, "record_number", NF90_INT, nlocs_dimid, varid_recn))
-   call check(nf90_put_att(grpid_metadata, varid_recn, "longname", "GNSS RO profile identifier"))
-   call check(nf90_put_att(grpid_metadata, varid_recn, "units",  "1"))
-   call check(nf90_def_var_fill(grpid_metadata, varid_recn, 0, i_missing))
-   ! MetaData/gnss_sat_class
-   call check(nf90_def_var(grpid_metadata, "gnss_sat_class", NF90_INT, nlocs_dimid, varid_sclf))
-   call check(nf90_put_att(grpid_metadata, varid_sclf, "longname", &
-      "GNSS satellite classification, e.g., 401=GPS, 402=GLONASS"))
-   call check(nf90_put_att(grpid_metadata, varid_sclf, "units", "1"))
-   call check(nf90_def_var_fill(grpid_metadata, varid_sclf, 0, i_missing))
-   ! MetaData/reference_sat_id
-   call check(nf90_def_var(grpid_metadata, "reference_sat_id", NF90_INT, nlocs_dimid, varid_ptid))
-   call check(nf90_put_att(grpid_metadata, varid_ptid, "longname", "GNSS satellite transmitter identifier (1-32)"))
-   call check(nf90_put_att(grpid_metadata, varid_ptid, "units", "1"))
-   call check(nf90_def_var_fill(grpid_metadata, varid_ptid, 0, i_missing))
-   ! MetaData/occulting_sat_id
-   call check(nf90_def_var(grpid_metadata, "occulting_sat_id", NF90_INT, nlocs_dimid, varid_said))
-   call check(nf90_put_att(grpid_metadata, varid_said, "longname",&
-      "Low Earth Orbit satellite identifier, e.g., COSMIC2=750-755"))
-   call check(nf90_put_att(grpid_metadata, varid_said, "units", "1"))
-   call check(nf90_def_var_fill(grpid_metadata, varid_said, 0, i_missing))
-   ! MetaData/occulting_sat_is
-   call check(nf90_def_var(grpid_metadata, "occulting_sat_is", NF90_INT, nlocs_dimid, varid_siid))
-   call check(nf90_put_att(grpid_metadata, varid_siid, "longname", "satellite instrument"))
-   call check(nf90_put_att(grpid_metadata, varid_siid, "units", "1"))
-   call check(nf90_def_var_fill(grpid_metadata, varid_siid, 0, i_missing))
-   ! MetaData/ascending_flag
-   call check(nf90_def_var(grpid_metadata, "ascending_flag", NF90_INT, nlocs_dimid, varid_asce))
-   call check(nf90_put_att(grpid_metadata, varid_asce, "longname", "the original occultation ascending/descending flag"))
-   call check(nf90_put_att(grpid_metadata, varid_asce, "valid_range", int((/ 0, 1 /))))
-   call check(nf90_put_att(grpid_metadata, varid_asce, "flag_values", int((/ 0, 1 /))))
-   call check(nf90_put_att(grpid_metadata, varid_asce, "flag_meanings", "descending ascending"))
-   call check(nf90_put_att(grpid_metadata, varid_asce, "units", "1"))
-   call check(nf90_def_var_fill(grpid_metadata, varid_asce, 0, i_missing))
-   ! MetaData/process_center
-   call check(nf90_def_var(grpid_metadata, "process_center", NF90_INT, nlocs_dimid, varid_ogce))
-   call check( nf90_put_att(grpid_metadata, varid_ogce, "longname", &
-      "originally data processing_center, e.g., 60 for UCAR, 94 for DMI, 78 for GFZ"))
-   call check(nf90_put_att(grpid_metadata, varid_ogce, "units", "1"))
-   call check(nf90_def_var_fill(grpid_metadata, varid_ogce, 0, i_missing))
-   ! ObsValue/refractivity
-   call check(nf90_def_var(grpid_obsvalue, "refractivity", NF90_FLOAT, nlocs_dimid, varid_ref))
-   call check(nf90_put_att(grpid_obsvalue, varid_ref, "longname", "Atmospheric refractivity"))
-   call check(nf90_put_att(grpid_obsvalue, varid_ref, "units", "N"))
-   call check(nf90_put_att(grpid_obsvalue, varid_ref, "valid_range", real((/ 0.0, 500.0 /))))
-   call check(nf90_def_var_fill(grpid_obsvalue, varid_ref, 0, real(r_missing)))
-   ! ObsError/refractivity
-   call check(nf90_def_var(grpid_obserror, "refractivity", NF90_FLOAT, nlocs_dimid, varid_refoe))
-   call check(nf90_put_att(grpid_obserror, varid_refoe, "longname", "Input error in atmospheric refractivity"))
-   call check(nf90_put_att(grpid_obserror, varid_refoe, "units", "N"))
-   call check(nf90_put_att(grpid_obserror, varid_refoe, "valid_range", real((/ 0.0, 10.0 /))))
-   call check(nf90_def_var_fill(grpid_obserror, varid_refoe, 0, real(r_missing)))
-   ! MetaData/altitude
-   call check(nf90_def_var(grpid_metadata, "altitude", NF90_FLOAT, nlocs_dimid, varid_msl))
-   call check(nf90_put_att(grpid_metadata, varid_msl, "longname", "Geometric altitude"))
-   call check(nf90_put_att(grpid_metadata, varid_msl, "units", "m"))
-   call check(nf90_def_var_fill(grpid_metadata, varid_msl, 0, real(r_missing)))
-   ! ObsValue/bending_angle
-   call check(nf90_def_var(grpid_obsvalue, "bending_angle", NF90_FLOAT, nlocs_dimid, varid_bnd))
-   call check(nf90_put_att(grpid_obsvalue, varid_bnd, "longname", "Bending Angle"))
-   call check(nf90_put_att(grpid_obsvalue, varid_bnd, "units", "radian"))
-   call check(nf90_put_att(grpid_obsvalue, varid_bnd, "valid_range", real((/ -0.001, 0.08 /))))
-   call check(nf90_def_var_fill(grpid_obsvalue, varid_bnd, 0, real(r_missing)))
-   ! ObsError/bending_angle
-   call check(nf90_def_var(grpid_obserror, "bending_angle", NF90_FLOAT, nlocs_dimid, varid_bndoe))
-   call check(nf90_put_att(grpid_obserror, varid_bndoe, "longname", "Input error in Bending Angle"))
-   call check(nf90_put_att(grpid_obserror, varid_bndoe, "units", "radian"))
-   call check(nf90_put_att(grpid_obserror, varid_bndoe, "valid_range", real((/ 0.0, 0.008 /))))
-   call check(nf90_def_var_fill(grpid_obserror, varid_bndoe, 0, real(r_missing)))
-   ! MetaData/impact_parameter
-   call check(nf90_def_var(grpid_metadata, "impact_parameter", NF90_FLOAT, nlocs_dimid, varid_impp))
-   call check(nf90_put_att(grpid_metadata, varid_impp, "longname", "distance from centre of curvature"))
-   call check(nf90_put_att(grpid_metadata, varid_impp, "units", "m"))
-   call check(nf90_put_att(grpid_metadata, varid_impp, "valid_range", real((/ 6200000.0, 6600000.0 /))))
-   call check(nf90_def_var_fill(grpid_metadata, varid_impp, 0, real(r_missing)))
-   ! MetaData/impact_height
-   call check(nf90_def_var(grpid_metadata, "impact_height", NF90_FLOAT, nlocs_dimid, varid_imph))
-   call check(nf90_put_att(grpid_metadata, varid_imph, "longname", "distance from mean sea level"))
-   call check(nf90_put_att(grpid_metadata, varid_imph, "units", "m"))
-   call check(nf90_put_att(grpid_metadata, varid_imph, "valid_range", real((/ 0.0, 200000.0 /))))
-   call check(nf90_def_var_fill(grpid_metadata, varid_imph, 0, real(r_missing)))
-   ! MetaData/sensor_azimuth_angle
-   call check(nf90_def_var(grpid_metadata, "sensor_azimuth_angle", NF90_FLOAT, nlocs_dimid, varid_azim))
-   call check(nf90_put_att(grpid_metadata, varid_azim, "longname", "GNSS->LEO line of sight"))
-   call check(nf90_put_att(grpid_metadata, varid_azim, "units", "degree"))
-   call check(nf90_put_att(grpid_metadata, varid_azim, "valid_range", real((/ 0.0, 360.0 /))))
-   call check(nf90_def_var_fill(grpid_metadata, varid_azim, 0, real(r_missing)))
-   ! MetaData/geoid_height_above_reference_ellipsoid
-   call check(nf90_def_var(grpid_metadata, "geoid_height_above_reference_ellipsoid", NF90_FLOAT, nlocs_dimid, varid_geoid))
-   call check(nf90_put_att(grpid_metadata, varid_geoid, "longname", "Geoid height above WGS-84 ellipsoid"))
-   call check(nf90_put_att(grpid_metadata, varid_geoid, "units", "m"))
-   call check(nf90_put_att(grpid_metadata, varid_geoid, "valid_range", real((/ -200.0, 200.0 /))))
-   call check(nf90_def_var_fill(grpid_metadata, varid_geoid, 0, real(r_missing)))
-   ! MetaData/earth_radius_of_curvature
-   call check(nf90_def_var(grpid_metadata, "earth_radius_of_curvature", NF90_FLOAT, nlocs_dimid, varid_rfict))
-   call check(nf90_put_att(grpid_metadata, varid_rfict, "longname", "Earth’s local radius of curvature"))
-   call check(nf90_put_att(grpid_metadata, varid_rfict, "units", "m"))
-   call check(nf90_put_att(grpid_metadata, varid_rfict, "valid_range", real((/ 6200000.0, 6600000.0 /))))
-   call check(nf90_def_var_fill(grpid_metadata, varid_rfict, 0, real(r_missing)))
+      ! create groups
+      call check(nf90_def_grp(ncid, 'MetaData', grpid_metadata))
+      call check(nf90_def_grp(ncid, 'ObsValue', grpid_obsvalue))
+      call check(nf90_def_grp(ncid, 'ObsError', grpid_obserror))
 
-   ! write variables
-   call check(nf90_enddef(ncid))  ! enters write mode
-   call check(nf90_put_var(grpid_obsvalue, varid_ref, gnssro_data%ref(1:ndata)))
-   call check(nf90_put_var(grpid_obserror, varid_refoe, gnssro_data%refoe_gsi(1:ndata)))
-   call check(nf90_put_var(grpid_obsvalue, varid_bnd, gnssro_data%bend_ang(1:ndata)))
-   call check(nf90_put_var(grpid_obserror, varid_bndoe, gnssro_data%bndoe_gsi(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_lat, gnssro_data%lat(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_lon, gnssro_data%lon(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_time, gnssro_data%time(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_epochtime, gnssro_data%epochtime(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_recn, gnssro_data%recn(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_said, gnssro_data%said(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_siid, gnssro_data%siid(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_ptid, gnssro_data%ptid(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_sclf, gnssro_data%sclf(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_asce, gnssro_data%asce(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_ogce, gnssro_data%ogce(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_msl, gnssro_data%msl_alt(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_impp, gnssro_data%impact_para(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_imph, &
-      gnssro_data%impact_para(1:ndata) - gnssro_data%rfict(1:ndata) - gnssro_data%geoid(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_azim, gnssro_data%azim(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_geoid, gnssro_data%geoid(1:ndata)))
-   call check(nf90_put_var(grpid_metadata, varid_rfict, gnssro_data%rfict(1:ndata)))
+      ! create variables, write their attributes and fill value
+      ! MetaData/latitude
+      call check(nf90_def_var(grpid_metadata, "latitude", NF90_FLOAT, nlocs_dimid, varid_lat))
+      call check(nf90_put_att(grpid_metadata, varid_lat, "units", "degree_north"))
+      call check(nf90_def_var_fill(grpid_metadata, varid_lat, 0, real(r_missing)))
+      ! MetaData/longitude
+      call check(nf90_def_var(grpid_metadata, "longitude", NF90_FLOAT, nlocs_dimid, varid_lon))
+      call check(nf90_put_att(grpid_metadata, varid_lon, "units", "degree_east"))
+      call check(nf90_def_var_fill(grpid_metadata, varid_lon, 0, real(r_missing)))
+      ! MetaData/time
+      call check(nf90_def_var(grpid_metadata, "time", NF90_FLOAT, nlocs_dimid, varid_time))
+      call check(nf90_put_att(grpid_metadata, varid_time, "longname", "time offset to analysis time"))
+      call check(nf90_put_att(grpid_metadata, varid_time, "units", "hour"))
+      call check(nf90_def_var_fill(grpid_metadata, varid_time, 0, real(r_missing)))
+      ! MetaData/dateTime
+      call check(nf90_def_var(grpid_metadata, "dateTime", NF90_INT64, nlocs_dimid, varid_epochtime))
+      call check(nf90_put_att(grpid_metadata, varid_epochtime, "units", "seconds since 1970-01-01T00:00:00Z"))
+      call check(nf90_def_var_fill(grpid_metadata, varid_epochtime, 0, i64_missing))
+      ! MetaData/record_number
+      call check(nf90_def_var(grpid_metadata, "record_number", NF90_INT, nlocs_dimid, varid_recn))
+      call check(nf90_put_att(grpid_metadata, varid_recn, "longname", "GNSS RO profile identifier"))
+      call check(nf90_put_att(grpid_metadata, varid_recn, "units",  "1"))
+      call check(nf90_def_var_fill(grpid_metadata, varid_recn, 0, i_missing))
+      ! MetaData/gnss_sat_class
+      call check(nf90_def_var(grpid_metadata, "gnss_sat_class", NF90_INT, nlocs_dimid, varid_sclf))
+      call check(nf90_put_att(grpid_metadata, varid_sclf, "longname", &
+         "GNSS satellite classification, e.g., 401=GPS, 402=GLONASS"))
+      call check(nf90_put_att(grpid_metadata, varid_sclf, "units", "1"))
+      call check(nf90_def_var_fill(grpid_metadata, varid_sclf, 0, i_missing))
+      ! MetaData/reference_sat_id
+      call check(nf90_def_var(grpid_metadata, "reference_sat_id", NF90_INT, nlocs_dimid, varid_ptid))
+      call check(nf90_put_att(grpid_metadata, varid_ptid, "longname", "GNSS satellite transmitter identifier (1-32)"))
+      call check(nf90_put_att(grpid_metadata, varid_ptid, "units", "1"))
+      call check(nf90_def_var_fill(grpid_metadata, varid_ptid, 0, i_missing))
+      ! MetaData/occulting_sat_id
+      call check(nf90_def_var(grpid_metadata, "occulting_sat_id", NF90_INT, nlocs_dimid, varid_said))
+      call check(nf90_put_att(grpid_metadata, varid_said, "longname",&
+         "Low Earth Orbit satellite identifier, e.g., COSMIC2=750-755"))
+      call check(nf90_put_att(grpid_metadata, varid_said, "units", "1"))
+      call check(nf90_def_var_fill(grpid_metadata, varid_said, 0, i_missing))
+      ! MetaData/occulting_sat_is
+      call check(nf90_def_var(grpid_metadata, "occulting_sat_is", NF90_INT, nlocs_dimid, varid_siid))
+      call check(nf90_put_att(grpid_metadata, varid_siid, "longname", "satellite instrument"))
+      call check(nf90_put_att(grpid_metadata, varid_siid, "units", "1"))
+      call check(nf90_def_var_fill(grpid_metadata, varid_siid, 0, i_missing))
+      ! MetaData/ascending_flag
+      call check(nf90_def_var(grpid_metadata, "ascending_flag", NF90_INT, nlocs_dimid, varid_asce))
+      call check(nf90_put_att(grpid_metadata, varid_asce, "longname", "the original occultation ascending/descending flag"))
+      call check(nf90_put_att(grpid_metadata, varid_asce, "valid_range", int((/ 0, 1 /))))
+      call check(nf90_put_att(grpid_metadata, varid_asce, "flag_values", int((/ 0, 1 /))))
+      call check(nf90_put_att(grpid_metadata, varid_asce, "flag_meanings", "descending ascending"))
+      call check(nf90_put_att(grpid_metadata, varid_asce, "units", "1"))
+      call check(nf90_def_var_fill(grpid_metadata, varid_asce, 0, i_missing))
+      ! MetaData/process_center
+      call check(nf90_def_var(grpid_metadata, "process_center", NF90_INT, nlocs_dimid, varid_ogce))
+      call check( nf90_put_att(grpid_metadata, varid_ogce, "longname", &
+         "originally data processing_center, e.g., 60 for UCAR, 94 for DMI, 78 for GFZ"))
+      call check(nf90_put_att(grpid_metadata, varid_ogce, "units", "1"))
+      call check(nf90_def_var_fill(grpid_metadata, varid_ogce, 0, i_missing))
+      ! ObsValue/refractivity
+      call check(nf90_def_var(grpid_obsvalue, "refractivity", NF90_FLOAT, nlocs_dimid, varid_ref))
+      call check(nf90_put_att(grpid_obsvalue, varid_ref, "longname", "Atmospheric refractivity"))
+      call check(nf90_put_att(grpid_obsvalue, varid_ref, "units", "N"))
+      call check(nf90_put_att(grpid_obsvalue, varid_ref, "valid_range", real((/ 0.0, 500.0 /))))
+      call check(nf90_def_var_fill(grpid_obsvalue, varid_ref, 0, real(r_missing)))
+      ! ObsError/refractivity
+      call check(nf90_def_var(grpid_obserror, "refractivity", NF90_FLOAT, nlocs_dimid, varid_refoe))
+      call check(nf90_put_att(grpid_obserror, varid_refoe, "longname", "Input error in atmospheric refractivity"))
+      call check(nf90_put_att(grpid_obserror, varid_refoe, "units", "N"))
+      call check(nf90_put_att(grpid_obserror, varid_refoe, "valid_range", real((/ 0.0, 10.0 /))))
+      call check(nf90_def_var_fill(grpid_obserror, varid_refoe, 0, real(r_missing)))
+      ! MetaData/altitude
+      call check(nf90_def_var(grpid_metadata, "altitude", NF90_FLOAT, nlocs_dimid, varid_msl))
+      call check(nf90_put_att(grpid_metadata, varid_msl, "longname", "Geometric altitude"))
+      call check(nf90_put_att(grpid_metadata, varid_msl, "units", "m"))
+      call check(nf90_def_var_fill(grpid_metadata, varid_msl, 0, real(r_missing)))
+      ! ObsValue/bending_angle
+      call check(nf90_def_var(grpid_obsvalue, "bending_angle", NF90_FLOAT, nlocs_dimid, varid_bnd))
+      call check(nf90_put_att(grpid_obsvalue, varid_bnd, "longname", "Bending Angle"))
+      call check(nf90_put_att(grpid_obsvalue, varid_bnd, "units", "radian"))
+      call check(nf90_put_att(grpid_obsvalue, varid_bnd, "valid_range", real((/ -0.001, 0.08 /))))
+      call check(nf90_def_var_fill(grpid_obsvalue, varid_bnd, 0, real(r_missing)))
+      ! ObsError/bending_angle
+      call check(nf90_def_var(grpid_obserror, "bending_angle", NF90_FLOAT, nlocs_dimid, varid_bndoe))
+      call check(nf90_put_att(grpid_obserror, varid_bndoe, "longname", "Input error in Bending Angle"))
+      call check(nf90_put_att(grpid_obserror, varid_bndoe, "units", "radian"))
+      call check(nf90_put_att(grpid_obserror, varid_bndoe, "valid_range", real((/ 0.0, 0.008 /))))
+      call check(nf90_def_var_fill(grpid_obserror, varid_bndoe, 0, real(r_missing)))
+      ! MetaData/impact_parameter
+      call check(nf90_def_var(grpid_metadata, "impact_parameter", NF90_FLOAT, nlocs_dimid, varid_impp))
+      call check(nf90_put_att(grpid_metadata, varid_impp, "longname", "distance from centre of curvature"))
+      call check(nf90_put_att(grpid_metadata, varid_impp, "units", "m"))
+      call check(nf90_put_att(grpid_metadata, varid_impp, "valid_range", real((/ 6200000.0, 6600000.0 /))))
+      call check(nf90_def_var_fill(grpid_metadata, varid_impp, 0, real(r_missing)))
+      ! MetaData/impact_height
+      call check(nf90_def_var(grpid_metadata, "impact_height", NF90_FLOAT, nlocs_dimid, varid_imph))
+      call check(nf90_put_att(grpid_metadata, varid_imph, "longname", "distance from mean sea level"))
+      call check(nf90_put_att(grpid_metadata, varid_imph, "units", "m"))
+      call check(nf90_put_att(grpid_metadata, varid_imph, "valid_range", real((/ 0.0, 200000.0 /))))
+      call check(nf90_def_var_fill(grpid_metadata, varid_imph, 0, real(r_missing)))
+      ! MetaData/sensor_azimuth_angle
+      call check(nf90_def_var(grpid_metadata, "sensor_azimuth_angle", NF90_FLOAT, nlocs_dimid, varid_azim))
+      call check(nf90_put_att(grpid_metadata, varid_azim, "longname", "GNSS->LEO line of sight"))
+      call check(nf90_put_att(grpid_metadata, varid_azim, "units", "degree"))
+      call check(nf90_put_att(grpid_metadata, varid_azim, "valid_range", real((/ 0.0, 360.0 /))))
+      call check(nf90_def_var_fill(grpid_metadata, varid_azim, 0, real(r_missing)))
+      ! MetaData/geoid_height_above_reference_ellipsoid
+      call check(nf90_def_var(grpid_metadata, "geoid_height_above_reference_ellipsoid", NF90_FLOAT, nlocs_dimid, varid_geoid))
+      call check(nf90_put_att(grpid_metadata, varid_geoid, "longname", "Geoid height above WGS-84 ellipsoid"))
+      call check(nf90_put_att(grpid_metadata, varid_geoid, "units", "m"))
+      call check(nf90_put_att(grpid_metadata, varid_geoid, "valid_range", real((/ -200.0, 200.0 /))))
+      call check(nf90_def_var_fill(grpid_metadata, varid_geoid, 0, real(r_missing)))
+      ! MetaData/earth_radius_of_curvature
+      call check(nf90_def_var(grpid_metadata, "earth_radius_of_curvature", NF90_FLOAT, nlocs_dimid, varid_rfict))
+      call check(nf90_put_att(grpid_metadata, varid_rfict, "longname", "Earth’s local radius of curvature"))
+      call check(nf90_put_att(grpid_metadata, varid_rfict, "units", "m"))
+      call check(nf90_put_att(grpid_metadata, varid_rfict, "valid_range", real((/ 6200000.0, 6600000.0 /))))
+      call check(nf90_def_var_fill(grpid_metadata, varid_rfict, 0, real(r_missing)))
 
-   ! close file
-   call check(nf90_close(ncid))
-end subroutine
+      ! write variables
+      call check(nf90_enddef(ncid))  ! enters write mode
+      call check(nf90_put_var(grpid_obsvalue, varid_ref, gnssro_data%ref(1:ndata)))
+      call check(nf90_put_var(grpid_obserror, varid_refoe, gnssro_data%refoe_gsi(1:ndata)))
+      call check(nf90_put_var(grpid_obsvalue, varid_bnd, gnssro_data%bend_ang(1:ndata)))
+      call check(nf90_put_var(grpid_obserror, varid_bndoe, gnssro_data%bndoe_gsi(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_lat, gnssro_data%lat(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_lon, gnssro_data%lon(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_time, gnssro_data%time(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_epochtime, gnssro_data%epochtime(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_recn, gnssro_data%recn(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_said, gnssro_data%said(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_siid, gnssro_data%siid(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_ptid, gnssro_data%ptid(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_sclf, gnssro_data%sclf(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_asce, gnssro_data%asce(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_ogce, gnssro_data%ogce(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_msl, gnssro_data%msl_alt(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_impp, gnssro_data%impact_para(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_imph, &
+         gnssro_data%impact_para(1:ndata) - gnssro_data%rfict(1:ndata) - gnssro_data%geoid(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_azim, gnssro_data%azim(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_geoid, gnssro_data%geoid(1:ndata)))
+      call check(nf90_put_var(grpid_metadata, varid_rfict, gnssro_data%rfict(1:ndata)))
 
-subroutine deallocate_gnssro_data_array()
-   deallocate(gnssro_data%said)
-   deallocate(gnssro_data%siid)
-   deallocate(gnssro_data%sclf)
-   deallocate(gnssro_data%ptid)
-   deallocate(gnssro_data%recn)
-   deallocate(gnssro_data%asce)
-   deallocate(gnssro_data%ogce)
-   deallocate(gnssro_data%time)
-   deallocate(gnssro_data%epochtime)
-   deallocate(gnssro_data%lat)
-   deallocate(gnssro_data%lon)
-   deallocate(gnssro_data%rfict)
-   deallocate(gnssro_data%azim)
-   deallocate(gnssro_data%geoid)
-   deallocate(gnssro_data%msl_alt)
-   deallocate(gnssro_data%ref)
-   deallocate(gnssro_data%refoe_gsi)
-   deallocate(gnssro_data%bend_ang)
-   deallocate(gnssro_data%impact_para)
-   deallocate(gnssro_data%bndoe_gsi)
-end subroutine
+      ! close file
+      call check(nf90_close(ncid))
+   end subroutine
 
-!contains
- subroutine check(status)
-    integer, intent ( in) :: status
-    
-    if(status /= nf90_noerr) then 
-     print *, trim(nf90_strerror(status))
-      stop "Stopped"
-    end if
 
+   subroutine deallocate_gnssro_data_array()
+      deallocate(gnssro_data%said)
+      deallocate(gnssro_data%siid)
+      deallocate(gnssro_data%sclf)
+      deallocate(gnssro_data%ptid)
+      deallocate(gnssro_data%recn)
+      deallocate(gnssro_data%asce)
+      deallocate(gnssro_data%ogce)
+      deallocate(gnssro_data%time)
+      deallocate(gnssro_data%epochtime)
+      deallocate(gnssro_data%lat)
+      deallocate(gnssro_data%lon)
+      deallocate(gnssro_data%rfict)
+      deallocate(gnssro_data%azim)
+      deallocate(gnssro_data%geoid)
+      deallocate(gnssro_data%msl_alt)
+      deallocate(gnssro_data%ref)
+      deallocate(gnssro_data%refoe_gsi)
+      deallocate(gnssro_data%bend_ang)
+      deallocate(gnssro_data%impact_para)
+      deallocate(gnssro_data%bndoe_gsi)
+   end subroutine
+
+
+   subroutine check(status)
+      integer, intent ( in) :: status
+      if(status /= nf90_noerr) then 
+         print *, trim(nf90_strerror(status))
+         stop "Stopped"
+      end if
   end subroutine check  
 
 
-subroutine  refractivity_err_gsi(obsLat, obsZ, GlobalModel, obsErr)
-real(r_kind),  intent(in)  :: obsLat,  obsZ
-real(r_kind),  intent(out) :: obsErr
-logical,       intent(in)  :: GlobalModel
-real(r_kind)               :: obsZ_km
+   subroutine  refractivity_err_gsi(obsLat, obsZ, GlobalModel, obsErr)
+      real(r_kind),  intent(in)  :: obsLat,  obsZ
+      real(r_kind),  intent(out) :: obsErr
+      logical,       intent(in)  :: GlobalModel
+      real(r_kind)               :: obsZ_km
 
-obsZ_km  = obsZ / 1000.0
-
-if( GlobalModel ) then ! for global
-
-     if( obsLat>= 20.0 .or.obsLat<= -20.0 ) then
-         obsErr=-1.321_r_kind+0.341_r_kind*obsZ_km-0.005_r_kind*obsZ_km**2
-     else
-       if(obsZ_km > 10.0) then
-          obsErr=2.013_r_kind-0.060_r_kind*obsZ_km+0.0045_r_kind*obsZ_km**2
-       else
-          obsErr=-1.18_r_kind+0.058_r_kind*obsZ_km+0.025_r_kind*obsZ_km**2
-       endif
-     endif
-     obsErr = 1.0_r_kind/abs(exp(obsErr))
-
-else ! for regional 
-     if( obsLat >= 20.0 .or.obsLat <= -20.0 ) then
-         if (obsZ_km > 10.00) then
-             obsErr =-1.321_r_kind+0.341_r_kind*obsZ_km-0.005_r_kind*obsZ_km**2
+      obsZ_km  = obsZ / 1000.0
+      if( GlobalModel ) then ! for global
+         if( obsLat>= 20.0 .or.obsLat<= -20.0 ) then
+            obsErr=-1.321_r_kind+0.341_r_kind*obsZ_km-0.005_r_kind*obsZ_km**2
          else
-             obsErr =-1.2_r_kind+0.065_r_kind*obsZ_km+0.021_r_kind*obsZ_km**2
+            if(obsZ_km > 10.0) then
+               obsErr=2.013_r_kind-0.060_r_kind*obsZ_km+0.0045_r_kind*obsZ_km**2
+            else
+               obsErr=-1.18_r_kind+0.058_r_kind*obsZ_km+0.025_r_kind*obsZ_km**2
+            endif
          endif
-     else
-         if(obsZ_km > 10.00) then
-            obsErr =2.013_r_kind-0.120_r_kind*obsZ_km+0.0065_r_kind*obsZ_km**2
+         obsErr = 1.0_r_kind/abs(exp(obsErr))
+      else ! for regional 
+         if( obsLat >= 20.0 .or.obsLat <= -20.0 ) then
+            if (obsZ_km > 10.00) then
+               obsErr =-1.321_r_kind+0.341_r_kind*obsZ_km-0.005_r_kind*obsZ_km**2
+            else
+               obsErr =-1.2_r_kind+0.065_r_kind*obsZ_km+0.021_r_kind*obsZ_km**2
+            endif
          else
-            obsErr =-1.19_r_kind+0.03_r_kind*obsZ_km+0.023_r_kind*obsZ_km**2
+            if(obsZ_km > 10.00) then
+               obsErr =2.013_r_kind-0.120_r_kind*obsZ_km+0.0065_r_kind*obsZ_km**2
+            else
+               obsErr =-1.19_r_kind+0.03_r_kind*obsZ_km+0.023_r_kind*obsZ_km**2
+            endif
          endif
-     endif
-     obsErr = 1.0_r_kind/abs(exp(obsErr))
-endif
+         obsErr = 1.0_r_kind/abs(exp(obsErr))
+      endif
+   end subroutine refractivity_err_gsi
 
-end subroutine refractivity_err_gsi
 
-subroutine  bendingangle_err_gsi(obsLat, obsZ,  obsErr, ogce, said)
-real(r_kind), intent(in)   :: obsLat,  obsZ
-integer(i_kind), intent(in) :: ogce, said
-real(r_kind), intent(out)  :: obsErr
-real(r_kind)               :: obsZ_km
+   subroutine  bendingangle_err_gsi(obsLat, obsZ,  obsErr, ogce, said)
+      real(r_kind), intent(in)   :: obsLat,  obsZ
+      integer(i_kind), intent(in) :: ogce, said
+      real(r_kind), intent(out)  :: obsErr
+      real(r_kind)               :: obsZ_km
 
-obsZ_km  = obsZ / 1000.0
-if((said==41).or.(said==722).or.(said==723).or.(said==42).or.&
-                 (said>=3.and.said<=5).or.(said==821.or.(said==421)).or.(said==440).or.(said==43) .or. &
-                  (ogce/=60) ) then
-     if( abs(obsLat)>= 40.00 ) then
-
-        if(obsZ_km>12.) then
-          obsErr=0.19032_r_kind+0.287535_r_kind*obsZ_km-0.00260813_r_kind*obsZ_km**2
-        else
-          obsErr=-3.20978_r_kind+1.26964_r_kind*obsZ_km-0.0622538_r_kind*obsZ_km**2
-        endif
-     else
-        if(obsZ_km>18.) then
-          obsErr=-1.87788_r_kind+0.354718_r_kind*obsZ_km-0.00313189_r_kind*obsZ_km**2
-        else
-          obsErr=-2.41024_r_kind+0.806594_r_kind*obsZ_km-0.027257_r_kind*obsZ_km**2
-        endif
-     endif
-     obsErr = 0.001_r_kind/abs(exp(obsErr))
-
- else !!!! CDAAC processing
-     if( abs(obsLat)>= 40.00 ) then
-         if (obsZ_km > 12.00) then
-            obsErr=-0.685627_r_kind+0.377174_r_kind*obsZ_km-0.00421934_r_kind*obsZ_km**2
+      obsZ_km  = obsZ / 1000.0
+      if((said==41).or.(said==722).or.(said==723).or.(said==42).or.&
+         (said>=3.and.said<=5).or.(said==821.or.(said==421)).or.(said==440).or.(said==43) .or. (ogce/=60) ) then
+         if( abs(obsLat)>= 40.00 ) then
+            if(obsZ_km>12.) then
+               obsErr=0.19032_r_kind+0.287535_r_kind*obsZ_km-0.00260813_r_kind*obsZ_km**2
+            else
+               obsErr=-3.20978_r_kind+1.26964_r_kind*obsZ_km-0.0622538_r_kind*obsZ_km**2
+            endif
          else
-            obsErr=-3.27737_r_kind+1.20003_r_kind*obsZ_km-0.0558024_r_kind*obsZ_km**2
+            if(obsZ_km>18.) then
+               obsErr=-1.87788_r_kind+0.354718_r_kind*obsZ_km-0.00313189_r_kind*obsZ_km**2
+            else
+               obsErr=-2.41024_r_kind+0.806594_r_kind*obsZ_km-0.027257_r_kind*obsZ_km**2
+            endif
          endif
-      else
-         if(obsZ_km >18.00) then
-            obsErr=-2.73867_r_kind+0.447663_r_kind*obsZ_km-0.00475603_r_kind*obsZ_km**2
+         obsErr = 0.001_r_kind/abs(exp(obsErr))
+      else !!!! CDAAC processing
+         if( abs(obsLat)>= 40.00 ) then
+            if (obsZ_km > 12.00) then
+               obsErr=-0.685627_r_kind+0.377174_r_kind*obsZ_km-0.00421934_r_kind*obsZ_km**2
+            else
+               obsErr=-3.27737_r_kind+1.20003_r_kind*obsZ_km-0.0558024_r_kind*obsZ_km**2
+            endif
          else
-            obsErr=-3.45303_r_kind+0.908216_r_kind*obsZ_km-0.0293331_r_kind*obsZ_km**2
+            if(obsZ_km >18.00) then
+               obsErr=-2.73867_r_kind+0.447663_r_kind*obsZ_km-0.00475603_r_kind*obsZ_km**2
+            else
+               obsErr=-3.45303_r_kind+0.908216_r_kind*obsZ_km-0.0293331_r_kind*obsZ_km**2
+            endif
          endif
-     endif
-     obsErr = 0.001_r_kind/abs(exp(obsErr))
+         obsErr = 0.001_r_kind/abs(exp(obsErr))
+      endif
+   end subroutine bendingangle_err_gsi
 
-endif
 
-end subroutine bendingangle_err_gsi
-!!!!!!________________________________________________________  
-
-!!!!!! SUBROUTINE W3FS21 was copied from GSI/src/libs/w3nco_v2.0.6/w3fs21.f and iw3jdn.f
-SUBROUTINE W3FS21(IDATE, NMIN)
-    INTEGER  IDATE(5)
-    INTEGER  NMIN
-    INTEGER  IYEAR, NDAYS, IJDN
-    INTEGER  JDN78
-    DATA  JDN78 / 2443510 /
-    NMIN  = 0
-
-    IYEAR = IDATE(1)
-
-    IF (IYEAR.LE.99) THEN
-        IF (IYEAR.LT.78) THEN
+   !!!!!! SUBROUTINE W3FS21 was copied from GSI/src/libs/w3nco_v2.0.6/w3fs21.f and iw3jdn.f
+   SUBROUTINE W3FS21(IDATE, NMIN)
+      INTEGER  IDATE(5)
+      INTEGER  NMIN
+      INTEGER  IYEAR, NDAYS, IJDN
+      INTEGER  JDN78
+      DATA  JDN78 / 2443510 /
+      
+      NMIN  = 0
+      IYEAR = IDATE(1)
+      IF (IYEAR.LE.99) THEN
+         IF (IYEAR.LT.78) THEN
             IYEAR = IYEAR + 2000
-        ELSE
+         ELSE
             IYEAR = IYEAR + 1900
-        ENDIF
-    ENDIF
+         ENDIF
+      ENDIF
 
-!   COMPUTE JULIAN DAY NUMBER FROM YEAR, MONTH, DAY
-    IJDN  = IDATE(3) - 32075      &
-             + 1461 * (IYEAR + 4800 + (IDATE(2) - 14) / 12) / 4  &
-             + 367 * (IDATE(2)- 2 - (IDATE(2) -14) / 12 * 12) / 12   &
-             - 3 * ((IYEAR + 4900 + (IDATE(2) - 14) / 12) / 100) / 4
+      ! COMPUTE JULIAN DAY NUMBER FROM YEAR, MONTH, DAY
+      IJDN  = IDATE(3) - 32075      &
+         + 1461 * (IYEAR + 4800 + (IDATE(2) - 14) / 12) / 4  &
+         + 367 * (IDATE(2)- 2 - (IDATE(2) -14) / 12 * 12) / 12   &
+         - 3 * ((IYEAR + 4900 + (IDATE(2) - 14) / 12) / 100) / 4
 
-!   SUBTRACT JULIAN DAY NUMBER OF JAN 1,1978 TO GET THE
-!   NUMBER OF DAYS BETWEEN DATES
-    NDAYS = IJDN - JDN78
-    NMIN = NDAYS * 1440 + IDATE(4) * 60 + IDATE(5)
-    RETURN
-END SUBROUTINE W3FS21
+      ! SUBTRACT JULIAN DAY NUMBER OF JAN 1,1978 TO GET THE
+      ! NUMBER OF DAYS BETWEEN DATES
+      NDAYS = IJDN - JDN78
+      NMIN = NDAYS * 1440 + IDATE(4) * 60 + IDATE(5)
+      RETURN
+   END SUBROUTINE W3FS21
 
-!-------------------------------------------------------------
-! written by H. ZHANG based w3nco_v2.0.6/w3fs21.f and iw3jdn.f
-! calculating epoch time since January 1, 1970
-SUBROUTINE epochtimecalculator(IDATE, EPOCHTIME)
-    INTEGER    IDATE(6)
-    INTEGER    NMIN
-    INTEGER    IYEAR, NDAYS, IJDN
-    INTEGER(8) epochtime
-    INTEGER    JDN1970
-    DATA  JDN1970 / 2440588 /
+   
+   !-------------------------------------------------------------
+   ! written by H. ZHANG based w3nco_v2.0.6/w3fs21.f and iw3jdn.f
+   ! calculating epoch time since January 1, 1970
+   SUBROUTINE epochtimecalculator(IDATE, EPOCHTIME)
+      INTEGER    IDATE(6)
+      INTEGER    NMIN
+      INTEGER    IYEAR, NDAYS, IJDN
+      INTEGER(8) epochtime
+      INTEGER    JDN1970
+      DATA  JDN1970 / 2440588 /
 
-    NMIN  = 0
-    IYEAR = IDATE(1)
-    IF (IYEAR.LE.99) THEN
-        IF (IYEAR.LT.78) THEN
+      NMIN  = 0
+      IYEAR = IDATE(1)
+      IF (IYEAR.LE.99) THEN
+         IF (IYEAR.LT.78) THEN
             IYEAR = IYEAR + 2000
-        ELSE
+         ELSE
             IYEAR = IYEAR + 1900
-        ENDIF
-    ENDIF
-!   COMPUTE JULIAN DAY NUMBER FROM YEAR, MONTH, DAY
-    IJDN  = IDATE(3) - 32075      &
-             + 1461 * (IYEAR + 4800 + (IDATE(2) - 14) / 12) / 4  &
-             + 367 * (IDATE(2)- 2 - (IDATE(2) -14) / 12 * 12) / 12   &
-             - 3 * ((IYEAR + 4900 + (IDATE(2) - 14) / 12) / 100) / 4
-!   SUBTRACT JULIAN DAY NUMBER OF JAN 1,1970 TO GET THE
-!   NUMBER OF DAYS BETWEEN DATES
-    NDAYS = IJDN - JDN1970
-    NMIN = NDAYS * 1440 + IDATE(4) * 60 + IDATE(5)
-    EPOCHTIME = NMIN * 60 + IDATE(6)
-END SUBROUTINE epochtimecalculator
+         ENDIF
+      ENDIF
+      ! COMPUTE JULIAN DAY NUMBER FROM YEAR, MONTH, DAY
+      IJDN  = IDATE(3) - 32075      &
+         + 1461 * (IYEAR + 4800 + (IDATE(2) - 14) / 12) / 4  &
+         + 367 * (IDATE(2)- 2 - (IDATE(2) -14) / 12 * 12) / 12   &
+         - 3 * ((IYEAR + 4900 + (IDATE(2) - 14) / 12) / 100) / 4
+      ! SUBTRACT JULIAN DAY NUMBER OF JAN 1,1970 TO GET THE
+      ! NUMBER OF DAYS BETWEEN DATES
+      NDAYS = IJDN - JDN1970
+      NMIN = NDAYS * 1440 + IDATE(4) * 60 + IDATE(5)
+      EPOCHTIME = NMIN * 60 + IDATE(6)
+   END SUBROUTINE epochtimecalculator
 
-!end program
 end module gnssro_bufr2ioda

--- a/obs2ioda-v2/src/gnssro_mod.f90
+++ b/obs2ioda-v2/src/gnssro_mod.f90
@@ -8,10 +8,38 @@
 module gnssro_bufr2ioda
 use netcdf
 implicit none
+private
+
+public :: read_write_gnssro
 
 integer, parameter :: i_kind  = selected_int_kind(8)    !4
 integer, parameter :: i_64    = selected_int_kind(10)   !8
 integer, parameter :: r_kind  = selected_real_kind(15)  !8
+
+type gnssro_type
+      integer(i_kind), allocatable, dimension(:)    :: said
+      integer(i_kind), allocatable, dimension(:)    :: siid
+      integer(i_kind), allocatable, dimension(:)    :: sclf
+      integer(i_kind), allocatable, dimension(:)    :: ptid
+      integer(i_kind), allocatable, dimension(:)    :: recn
+      integer(i_kind), allocatable, dimension(:)    :: asce
+      integer(i_kind), allocatable, dimension(:)    :: ogce
+      real(r_kind), allocatable, dimension(:)       :: time
+      integer(i_64),allocatable, dimension(:)     :: epochtime
+      real(r_kind), allocatable, dimension(:)     :: lat
+      real(r_kind), allocatable, dimension(:)     :: lon
+      real(r_kind), allocatable, dimension(:)     :: rfict
+      real(r_kind), allocatable, dimension(:)     :: azim
+      real(r_kind), allocatable, dimension(:)     :: geoid
+      real(r_kind), allocatable, dimension(:)     :: msl_alt
+      real(r_kind), allocatable, dimension(:)     :: ref
+      real(r_kind), allocatable, dimension(:)     :: refoe_gsi
+      real(r_kind), allocatable, dimension(:)     :: bend_ang
+      real(r_kind), allocatable, dimension(:)     :: impact_para
+      real(r_kind), allocatable, dimension(:)     :: bndoe_gsi
+end type gnssro_type
+
+type(gnssro_type) :: gnssro_data
 
 logical :: verbose = .false.
 
@@ -51,30 +79,6 @@ integer(i_kind),parameter :: maxlevs=500
 integer(i_kind),parameter :: n1ahdr=13
 integer(i_kind)           :: maxobs
 real(r_kind) :: timeo
-type gnssro_type
-      integer(i_kind), allocatable, dimension(:)    :: said
-      integer(i_kind), allocatable, dimension(:)    :: siid
-      integer(i_kind), allocatable, dimension(:)    :: sclf
-      integer(i_kind), allocatable, dimension(:)    :: ptid
-      integer(i_kind), allocatable, dimension(:)    :: recn
-      integer(i_kind), allocatable, dimension(:)    :: asce
-      integer(i_kind), allocatable, dimension(:)    :: ogce
-      real(r_kind), allocatable, dimension(:)       :: time
-      integer(i_64),allocatable, dimension(:)     :: epochtime
-      real(r_kind), allocatable, dimension(:)     :: lat
-      real(r_kind), allocatable, dimension(:)     :: lon
-      real(r_kind), allocatable, dimension(:)     :: rfict
-      real(r_kind), allocatable, dimension(:)     :: azim
-      real(r_kind), allocatable, dimension(:)     :: geoid
-      real(r_kind), allocatable, dimension(:)     :: msl_alt
-      real(r_kind), allocatable, dimension(:)     :: ref
-      real(r_kind), allocatable, dimension(:)     :: refoe_gsi
-      real(r_kind), allocatable, dimension(:)     :: bend_ang
-      real(r_kind), allocatable, dimension(:)     :: impact_para
-      real(r_kind), allocatable, dimension(:)     :: bndoe_gsi
-end type gnssro_type
-
-type(gnssro_type) :: gnssro_data
 
 real(r_kind),dimension(n1ahdr)     :: bfr1ahdr
 real(r_kind),dimension(50,maxlevs) :: data1b

--- a/obs2ioda-v2/src/gnssro_mod.f90
+++ b/obs2ioda-v2/src/gnssro_mod.f90
@@ -49,7 +49,6 @@ module gnssro_bufr2ioda
       real(r_kind), allocatable, dimension(:) :: impact_para
       real(r_kind), allocatable, dimension(:) :: bndoe_gsi
    end type gnssro_type
-   type(gnssro_type) :: gnssro_data
 
 contains
 
@@ -58,11 +57,12 @@ contains
       character(len = *), intent(in) :: outdir
       character(len = 10) :: anatime
       integer(i_kind) :: ndata, mincy, maxobs
+      type(gnssro_type) :: gnssro_data
       call get_buffer_information(trim(adjustl(infile)), anatime, mincy, maxobs)
-      call allocate_gnssro_data_array(maxobs)
-      call read_gnssro_data(trim(adjustl(infile)), mincy, ndata)
-      call write_gnssro_data(anatime, ndata, outdir)
-      call deallocate_gnssro_data_array()
+      call allocate_gnssro_data_array(gnssro_data, maxobs)
+      call read_gnssro_data(trim(adjustl(infile)), gnssro_data, mincy, ndata)
+      call write_gnssro_data(gnssro_data, anatime, ndata, outdir)
+      call deallocate_gnssro_data_array(gnssro_data)
    end subroutine read_write_gnssro
 
 
@@ -108,7 +108,8 @@ contains
    end subroutine
 
 
-   subroutine allocate_gnssro_data_array(maxobs)
+   subroutine allocate_gnssro_data_array(gnssro_data, maxobs)
+      type(gnssro_type), intent(out) :: gnssro_data  ! intent(out) automatically deallocates previously allocated arguments
       integer, intent(in) :: maxobs
       allocate(gnssro_data%said(maxobs))
       allocate(gnssro_data%siid(maxobs))
@@ -133,8 +134,9 @@ contains
    end subroutine
 
 
-   subroutine read_gnssro_data(infile, mincy, ndata)
+   subroutine read_gnssro_data(infile, gnssro_data, mincy, ndata)
       character(len = *), intent(in) :: infile
+      type(gnssro_type), intent(inout) :: gnssro_data
       integer(i_kind), intent(in) :: mincy
       integer(i_kind), intent(out) :: ndata
       integer(i_kind), parameter :: lnbufr = 10
@@ -326,7 +328,8 @@ contains
    end subroutine
 
 
-   subroutine write_gnssro_data(anatime, ndata, outdir)
+   subroutine write_gnssro_data(gnssro_data, anatime, ndata, outdir)
+      type(gnssro_type), intent(in) :: gnssro_data
       character(len = *), intent(in) :: anatime, outdir
       integer(i_kind), intent(in) :: ndata
       character(len = datelength) :: cdate
@@ -501,7 +504,8 @@ contains
    end subroutine
 
 
-   subroutine deallocate_gnssro_data_array()
+   subroutine deallocate_gnssro_data_array(gnssro_data)
+      type(gnssro_type), intent(inout) :: gnssro_data
       deallocate(gnssro_data%said)
       deallocate(gnssro_data%siid)
       deallocate(gnssro_data%sclf)


### PR DESCRIPTION
TYPE: enhancement

DESCRIPTION OF CHANGES:
This PR splits subroutine read_write_gnssro into multiple subroutines and improves the overall source formatting. The new subroutines correspond approximately to the following line numbers in the current main-branch file version (434c723):
- subroutine get_buffer_information: lines 108 - 135
- subroutine allocate_gnssro_data_array: lines 137 - 156
- subroutine read_gnssro_data: lines 160 - 331
- subroutine write_gnssro_data: lines 333 - 482
- subroutine deallocate_gnssro_data_array: lines 484 - 503

The derived type for gnssro data and commonly used parameters are further defined as module variables. The PR does not attempt to improve the source code inside the subroutines, in part because I am not familiar enough with the details of the GNSSRO observer network and the BUFR descriptors to make sense of the hard-coded constants.

TESTS CONDUCTED:
I have compared the IODA file generated with the original and refactored converter:
```
$ diff file1.h5 file2.h5
$ nccmp -dmgefs file1.h5 file2.h5
```
Both tests report that the files are bitwise identical.
