### PR TITLE
Ensure `to_c` Returns the C Address of a Trimmed Fortran String  

### DIFF
--- a/obs2ioda-v2/src/f_c_string_t_mod.f90
+++ b/obs2ioda-v2/src/f_c_string_t_mod.f90
@@ -78,12 +78,12 @@ contains
         character(len = *), intent(in) :: f_string
         type(c_ptr) :: c_string
         integer :: n
-        n = len(f_string)
+        n = len(trim(f_string))
         if (allocated(this%fc_string)) then
             deallocate(this%fc_string)
         end if
         allocate(character(len = n + 1) :: this%fc_string)
-        this%fc_string = f_string // c_null_char
+        this%fc_string = f_string(1:n) // c_null_char
         c_string = c_loc(this%fc_string)
     end function to_c
 

--- a/obs2ioda-v2/src/f_c_string_t_mod.f90
+++ b/obs2ioda-v2/src/f_c_string_t_mod.f90
@@ -78,7 +78,7 @@ contains
         character(len = *), intent(in) :: f_string
         type(c_ptr) :: c_string
         integer :: n
-        n = len(trim(f_string))
+        n = len_trim(f_string)
         if (allocated(this%fc_string)) then
             deallocate(this%fc_string)
         end if


### PR DESCRIPTION
### Description:  
This PR updates the `to_c` type-bound function in the `f_c_string_t` derived type to ensure that the returned C address corresponds to a null-terminated, **trimmed** version of the provided Fortran string. Previously, the function allocated space based on the full Fortran string length, which could lead to trailing whitespace when accessed from C.  

### Changes:  
- The function now calculates the **length of the trimmed Fortran string** (`n = len(trim(f_string))`), ensuring no unnecessary trailing spaces are included.  
- Memory is **dynamically allocated** to store the trimmed string with a null terminator (`c_null_char`).  
- The **C address** returned now properly corresponds to the **trimmed** Fortran string.  

