### PR TITLE
Add Support for Writing NetCDF Character Arrays from Fortran via C++ Wrapper  

### DIFF
--- a/obs2ioda-v2/src/cxx/netcdf_variable.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_variable.cc
@@ -1,8 +1,22 @@
 #include "netcdf_variable.h"
 #include "netcdf_file.h"
 #include "netcdf_error.h"
+#include <algorithm>
+#include <cstring>
 
 namespace Obs2Ioda {
+
+    std::vector<char> flattenCharPtrArray(const char *const *values, const int numStrings, const int stringSize) {
+        std::vector<char> contiguousValues(numStrings * stringSize + numStrings, ' ');
+
+        for (int i = 0; i < numStrings; ++i) {
+            auto len = static_cast<int>(std::strlen(values[i]));
+            std::copy_n(values[i], std::min(len, stringSize), contiguousValues.begin() + i * stringSize);
+            contiguousValues[i * stringSize + stringSize] = '\0';
+        }
+        return contiguousValues;
+    }
+
     int netcdfAddVar(
         int netcdfID,
         const char *groupName,
@@ -54,7 +68,18 @@ namespace Obs2Ioda {
                                        netCDF::NcGroup>(
                                        file->getGroup(
                                            groupName));
-            auto var = group->getVar(varName);
+            const auto var = group->getVar(varName);
+            auto varType = var.getType();
+            // Special handling for char arrays
+            if (varType == netCDF::ncChar) {
+                const auto contiguousValues = flattenCharPtrArray(
+                    reinterpret_cast<const char * const *>(values),
+                    static_cast<int>(var.getDims()[0].getSize()),
+                    static_cast<int>(var.getDims()[1].getSize())
+                );
+                var.putVar(contiguousValues.data());
+                return 0;
+            }
             var.putVar(values);
             return 0;
         } catch (netCDF::exceptions::NcException &e) {
@@ -99,6 +124,20 @@ namespace Obs2Ioda {
         const char *groupName,
         const char *varName,
         const float *values
+    ) {
+        return netcdfPutVar(
+            netcdfID,
+            groupName,
+            varName,
+            values
+        );
+    }
+
+    int netcdfPutVarChar(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        const char **values
     ) {
         return netcdfPutVar(
             netcdfID,

--- a/obs2ioda-v2/src/cxx/netcdf_variable.h
+++ b/obs2ioda-v2/src/cxx/netcdf_variable.h
@@ -67,6 +67,13 @@ namespace Obs2Ioda {
         const char **values
     );
 
+    int netcdfPutVarChar(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        const char **values
+    );
+
     /**
     * @brief Sets the fill mode and fill value for a variable in a NetCDF file.
     *

--- a/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
@@ -221,6 +221,19 @@ module netcdf_cxx_i_mod
             integer(c_int) :: c_netcdfPutVarString
         end function c_netcdfPutVarString
 
+        ! See documentation for `c_netcdfPutVarInt`.
+        function c_netcdfPutVarChar(&
+           netcdfID, groupName, varName, values) &
+           bind(C, name = "netcdfPutVarChar")
+            import :: c_int
+            import :: c_ptr
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: groupName
+            type(c_ptr), value, intent(in) :: varName
+            type(c_ptr), value, intent(in) :: values
+            integer(c_int) :: c_netcdfPutVarString
+        end function c_netcdfPutVarChar
+
         ! c_netcdfSetFillInt:
         !   Sets the fill mode and fill value for an NetCDF variable in the specified group
         !   or as a global variable.

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -3,7 +3,7 @@ module netcdf_cxx_mod
     use f_c_string_t_mod, only : f_c_string_t
     use f_c_string_1D_t_mod, only : f_c_string_1D_t
     use netcdf_cxx_i_mod, only : c_netcdfCreate, c_netcdfClose, c_netcdfAddGroup, c_netcdfAddDim, &
-            c_netcdfAddVar, c_netcdfPutVarInt, c_netcdfPutVarInt64, c_netcdfPutVarReal, c_netcdfPutVarString, &
+            c_netcdfAddVar, c_netcdfPutVarInt, c_netcdfPutVarInt64, c_netcdfPutVarReal, c_netcdfPutVarChar, &
             c_netcdfSetFillInt, c_netcdfSetFillInt64, c_netcdfSetFillReal, c_netcdfSetFillString, &
             c_netcdfPutAttInt, c_netcdfPutAttString
     implicit none
@@ -244,7 +244,7 @@ contains
 
         type is (character(len = *))
             c_values = f_c_string_1D_values%to_c(values)
-            netcdfPutVar = c_netcdfPutVarString(netcdfID, c_groupName, &
+            netcdfPutVar = c_netcdfPutVarChar(netcdfID, c_groupName, &
                     c_varName, c_values)
         class default
             netcdfPutVar = -2


### PR DESCRIPTION
#### Summary  
This PR enhances the NetCDF C++ wrapper interface to support writing NetCDF `char` array variables from Fortran. The goal is to ensure that the new C++-based interface produces **bitwise identical** NetCDF files compared to the existing Fortran implementation, allowing for direct validation through file comparisons.  

#### Changes  
- Implemented `flattenCharPtrArray`, a helper function to convert a 2D Fortran character array (`char**`) into a contiguous `std::vector<char>` for NetCDF storage.  
  - Ensures proper truncation/padding of strings to match NetCDF dimensions.  
  - Appends `'\0'` to each string to maintain consistency with Fortran’s fixed-width character handling.  
- Updated `netcdfPutVar` to detect `ncChar` variables and correctly flatten input before calling `putVar()`.  
- Ensured the new interface matches Fortran’s NetCDF output format exactly.  

#### Motivation  
To validate the correctness of the new NetCDF C++ interface, it must generate files that are **bitwise identical** to those created by the existing Fortran implementation. 

#### Testing  
- Verified bitwise equivalence of output files using:  
  - `nccmp -d` against reference files produced by the Fortran interface.  
- No differences were detected, confirming identical output.  
