### PR TITLE
Update `netcdfAddDim` to Return Dimension ID  

### DIFF
--- a/obs2ioda-v2/src/cxx/netcdf_dimension.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_dimension.cc
@@ -7,7 +7,8 @@ namespace Obs2Ioda {
         const int netcdfID,
         const char *groupName,
         const char *dimName,
-        const int len
+        const int len,
+        int *dimID
     ) {
         try {
             const auto file = FileMap::getInstance().getFile(netcdfID);
@@ -18,6 +19,7 @@ namespace Obs2Ioda {
                                        file->getGroup(
                                            groupName));
             auto dim = group->addDim(dimName, len);
+            *dimID = dim.getId();
             return 0;
         } catch (netCDF::exceptions::NcException &e) {
             return netcdfErrorMessage(

--- a/obs2ioda-v2/src/cxx/netcdf_dimension.h
+++ b/obs2ioda-v2/src/cxx/netcdf_dimension.h
@@ -22,6 +22,9 @@ namespace Obs2Ioda {
 * @param len
 *     The length of the dimension.
 *
+* @param dimID
+*     A pointer to an integer that will be set to the ID of the new dimension.
+*
 * @return
 *     - 0 on success.
 *     - A non-zero error code if an exception is encountered.
@@ -30,7 +33,8 @@ namespace Obs2Ioda {
         int netcdfID,
         const char *groupName,
         const char *dimName,
-        int len
+        int len,
+        int *dimID
     );
     }
 }

--- a/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
@@ -90,6 +90,9 @@ module netcdf_cxx_i_mod
         !     - dimName (type(c_ptr), intent(in), value):
         !       A C pointer to a null-terminated string specifying the name of the new dimension.
         !     - len (integer(c_int), intent(in), value):
+        !       The length of the new dimension.
+        !     - dimID (integer(c_int), intent(out)):
+        !      Receives the identifier of the newly created dimension.
         !
         !   Returns:
         !     - integer(c_int): Status code indicating the result of the operation:
@@ -101,7 +104,7 @@ module netcdf_cxx_i_mod
         !     - `dimName` must be valid C pointers pointing to null-terminated strings.
         !   ```
         function c_netcdfAddDim(&
-                netcdfID, groupName, dimName, len) &
+                netcdfID, groupName, dimName, len, dimID) &
                 bind(C, name = "netcdfAddDim")
             import :: c_int
             import :: c_ptr
@@ -109,6 +112,7 @@ module netcdf_cxx_i_mod
             type(c_ptr), value, intent(in) :: groupName
             type(c_ptr), value, intent(in) :: dimName
             integer(c_int), value, intent(in) :: len
+            integer(c_int), intent(out) :: dimID
             integer(c_int) :: c_netcdfAddDim
         end function c_netcdfAddDim
 

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -138,9 +138,8 @@ contains
         end if
         c_dimName = f_c_string_dimName%to_c(dimName)
 
-        status = c_netcdfAddDim(netcdfID, c_groupName, c_dimName, len, dimID)
+        netcdfAddDim = c_netcdfAddDim(netcdfID, c_groupName, c_dimName, len, dimID)
         dimID = dimID + 1
-        netcdfAddDim = status
     end function netcdfAddDim
 
     ! netcdfAddVar:

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -109,6 +109,8 @@ contains
     !       Name of the new dimension.
     !   - len (integer(c_int), intent(in), value):
     !       Length of the dimension.
+    !  - dimID (integer(c_int), intent(out)):
+    !       Identifier of the new dimension.
     !   - groupName (character(len=*), intent(in), optional):
     !       Name of the target group. If absent, the dimension is added as a global dimension.
     !
@@ -116,10 +118,11 @@ contains
     !    - integer(c_int): A status code indicating the outcome of the operation:
     !       - 0: Success.
     !       - Non-zero: Failure
-    function netcdfAddDim(netcdfID, dimName, len, groupName)
+    function netcdfAddDim(netcdfID, dimName, len, dimID, groupName)
         integer(c_int), value, intent(in) :: netcdfID
         character(len = *), intent(in) :: dimName
         integer(c_int), value, intent(in) :: len
+        integer(c_int), intent(out) :: dimID
         character(len = *), optional, intent(in) :: groupName
         integer(c_int) :: netcdfAddDim
         type(c_ptr) :: c_groupName
@@ -134,7 +137,7 @@ contains
         end if
         c_dimName = f_c_string_dimName%to_c(dimName)
 
-        netcdfAddDim = c_netcdfAddDim(netcdfID, c_groupName, c_dimName, len)
+        netcdfAddDim = c_netcdfAddDim(netcdfID, c_groupName, c_dimName, len, dimID)
 
     end function netcdfAddDim
 

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -129,6 +129,7 @@ contains
         type(c_ptr) :: c_dimName
         type(f_c_string_t) :: f_c_string_groupName
         type(f_c_string_t) :: f_c_string_dimName
+        integer(c_int) :: status
 
         if (present(groupName)) then
             c_groupName = f_c_string_groupName%to_c(groupName)
@@ -137,8 +138,9 @@ contains
         end if
         c_dimName = f_c_string_dimName%to_c(dimName)
 
-        netcdfAddDim = c_netcdfAddDim(netcdfID, c_groupName, c_dimName, len, dimID)
-
+        status = c_netcdfAddDim(netcdfID, c_groupName, c_dimName, len, dimID)
+        dimID = dimID + 1
+        netcdfAddDim = status
     end function netcdfAddDim
 
     ! netcdfAddVar:


### PR DESCRIPTION
#### Summary  
This PR updates `netcdfAddDim` to return the newly created dimension ID, allowing it to be easily retrieved in Fortran.  

#### Changes  
- Added an `int *dimID` parameter to `netcdfAddDim`.  
- Modified the function to store the dimension ID after calling `addDim()`:  
  ```cpp
  *dimID = dim.getId();
  ```
- Ensured behavior remains consistent while enabling Fortran compatibility.  

#### Testing  
- All tests passed in the dedicated testing branch [testing/netcdfAddDim_dimID_arg](https://github.com/NCAR/obs2ioda/tree/testing/netcdfAddDim_dimID_arg)
  - Tests verify `dimID` is set correctly and is incremented by one in fortran.
