### PR TITLE
Add support for writing NetCDF integer array attributes

### DIFF
--- a/obs2ioda-v2/src/cxx/netcdf_attribute.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_attribute.cc
@@ -46,7 +46,8 @@ namespace Obs2Ioda {
     }
 
     int netcdfPutAttIntArray(
-        int netcdfID, const char *attName, const int *attValue, const int attLen, const char *varName, const char *groupName
+        int netcdfID, const char *attName, const int *attValue,
+        const int attLen, const char *varName, const char *groupName
     ) {
         return netcdfPutAtt(
             netcdfID, attName, attValue, varName, groupName,

--- a/obs2ioda-v2/src/cxx/netcdf_attribute.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_attribute.cc
@@ -45,6 +45,14 @@ namespace Obs2Ioda {
         }
     }
 
+    int netcdfPutAttIntArray(
+        int netcdfID, const char *attName, const int *attValue, const int attLen, const char *varName, const char *groupName
+    ) {
+        return netcdfPutAtt(
+            netcdfID, attName, attValue, varName, groupName,
+            netCDF::NcType(netCDF::ncInt), attLen
+        );
+    }
 
     int netcdfPutAttInt(
         int netcdfID, const char *attName, const int *attValue,

--- a/obs2ioda-v2/src/cxx/netcdf_attribute.h
+++ b/obs2ioda-v2/src/cxx/netcdf_attribute.h
@@ -20,7 +20,8 @@ namespace Obs2Ioda {
      *         - Non-zero: Failure, with an error message logged.
      */
     int netcdfPutAttInt(
-        int netcdfID, const char *attName, const int *attValue, const char *varName, const char *groupName
+        int netcdfID, const char *attName, const int *attValue,
+        const char *varName, const char *groupName
     );
 
     /**
@@ -42,11 +43,13 @@ namespace Obs2Ioda {
      *         - Non-zero: Failure, with an error message logged.
      */
     int netcdfPutAttIntArray(
-        int netcdfID, const char *attName, const int *attValue, int attLen, const char *varName, const char *groupName
+        int netcdfID, const char *attName, const int *attValue,
+        int attLen, const char *varName, const char *groupName
     );
 
     int netcdfPutAttString(
-        int netcdfID, const char *attName, const char *attValue, const char *varName, const char *groupName
+        int netcdfID, const char *attName, const char *attValue,
+        const char *varName, const char *groupName
     );
     }
 }

--- a/obs2ioda-v2/src/cxx/netcdf_attribute.h
+++ b/obs2ioda-v2/src/cxx/netcdf_attribute.h
@@ -23,6 +23,28 @@ namespace Obs2Ioda {
         int netcdfID, const char *attName, const int *attValue, const char *varName, const char *groupName
     );
 
+    /**
+     * @brief Writes an integer array attribute to a variable, group, or as a global attribute in a NetCDF file.
+     *
+     * This function writes an attribute that contains an array of integer values.
+     * If `varName` is provided, the attribute is assigned to the specified variable.
+     * If `varName` is `NULL`, the attribute is assigned to the group.
+     * If both `groupName` and `varName` are `NULL`, the attribute is written as a global attribute.
+     *
+     * @param netcdfID The identifier of the NetCDF file where the attribute will be written.
+     * @param attName The name of the attribute to be written.
+     * @param attValue A pointer to the array of integer values to be assigned to the attribute.
+     * @param attLen The length of the integer array.
+     * @param varName The name of the variable to which the attribute will be attached. If `NULL`, the attribute is assigned to the group.
+     * @param groupName The name of the group containing the variable. If `NULL`, the root group is assumed.
+     * @return int A status code indicating the outcome of the operation:
+     *         - 0: Success.
+     *         - Non-zero: Failure, with an error message logged.
+     */
+    int netcdfPutAttIntArray(
+        int netcdfID, const char *attName, const int *attValue, int attLen, const char *varName, const char *groupName
+    );
+
     int netcdfPutAttString(
         int netcdfID, const char *attName, const char *attValue, const char *varName, const char *groupName
     );

--- a/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
@@ -363,6 +363,20 @@ module netcdf_cxx_i_mod
             integer(c_int) :: c_netcdfPutAttInt
         end function c_netcdfPutAttInt
 
+        function c_netcdfPutAttIntArray(&
+                netcdfID, attName, attValue, attLen, varName, groupName) &
+                bind(C, name = "netcdfPutAttIntArray")
+            import :: c_int
+            import :: c_ptr
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: attName
+            type(c_ptr), value, intent(in) :: attValue
+            integer(c_int), value, intent(in) :: attLen
+            type(c_ptr), value, intent(in) :: varName
+            type(c_ptr), value, intent(in) :: groupName
+            integer(c_int) :: c_netcdfPutAttIntArray
+        end function c_netcdfPutAttIntArray
+
         ! See documentation for `c_netcdfPutAttInt`.
         function c_netcdfPutAttString(&
                 netcdfID, attName, attValue, varName, groupName) &

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -338,7 +338,7 @@ contains
         end select
     end function netcdfSetFill
 
-    ! netcdfPutAttScalar:
+    ! netcdfPutAtt:
     !   Writes an attribute to a NetCDF variable, group, or as a global attribute.
     !
     !   Arguments:

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -447,7 +447,6 @@ contains
         type(c_ptr) :: c_groupName
         type(c_ptr) :: c_varName
         type(c_ptr) :: c_attValue
-        type(f_c_string_t) :: f_c_string_attValue
 
         if (present(groupName)) then
             c_groupName = f_c_string_groupName%to_c(groupName)

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -5,9 +5,14 @@ module netcdf_cxx_mod
     use netcdf_cxx_i_mod, only: c_netcdfCreate, c_netcdfClose, c_netcdfAddGroup, c_netcdfAddDim, &
             c_netcdfAddVar, c_netcdfPutVarInt, c_netcdfPutVarInt64, c_netcdfPutVarReal, c_netcdfPutVarDouble, c_netcdfPutVarChar, &
             c_netcdfSetFillInt, c_netcdfSetFillInt64, c_netcdfSetFillReal, c_netcdfSetFillString, &
-            c_netcdfPutAttInt, c_netcdfPutAttString
+            c_netcdfPutAttInt, c_netcdfPutAttString, c_netcdfPutAttIntArray
     implicit none
     public
+
+    interface netcdfPutAtt
+        module procedure netcdfPutAtt
+        module procedure netcdfPutAttArray
+    end interface netcdfPutAtt
 
 contains
 
@@ -333,7 +338,7 @@ contains
         end select
     end function netcdfSetFill
 
-    ! netcdfPutAtt:
+    ! netcdfPutAttScalar:
     !   Writes an attribute to a NetCDF variable, group, or as a global attribute.
     !
     !   Arguments:
@@ -398,5 +403,73 @@ contains
             netcdfPutAtt = -2
         end select
     end function netcdfPutAtt
+
+    ! netcdfPutAttArray:
+    !   Writes a 1D attribute to a NetCDF variable, group, or as a global attribute.
+    !
+    !   Arguments:
+    !     - netcdfID (integer(c_int), intent(in), value):
+    !       The identifier of the NetCDF file.
+    !     - attName (character(len=*), intent(in)):
+    !       The name of the attribute to be written.
+    !     - attValue (class(*), dimension(:), intent(in)):
+    !       The values of the attribute as a one-dimensional array. Must be of a
+    !       supported NetCDF type, such as integer(c_int) or character(len=*).
+    !       If the type is unsupported, the function will return an error
+    !       status code of -2.
+    !     - attLen (integer(c_int), intent(in), value):
+    !       The length of the attribute array.
+    !     - varName (character(len=*), intent(in), optional):
+    !       The name of the variable to which the attribute will be assigned.
+    !       If not provided, the attribute is assigned to the group instead.
+    !     - groupName (character(len=*), intent(in), optional):
+    !       The name of the group containing the variable.
+    !       If not provided, the attribute is written as a global attribute.
+    !
+    !   Returns:
+    !     - integer(c_int): A status code indicating the outcome of the operation:
+    !         -  0: Success.
+    !         - -1: NetCDF operation returned an error, but the error code was 0.
+    !         - -2: Unsupported type passed for attValue.
+    !         - Other nonzero values: Specific NetCDF error codes.
+    function netcdfPutAttArray(netcdfID, attName, attValue, attLen, varName, groupName)
+        integer(c_int), value, intent(in) :: netcdfID
+        character(len = *), intent(in) :: attName
+        class(*), intent(in) :: attValue(:)
+        integer(c_int), intent(in), value :: attLen
+        character(len = *), optional, intent(in) :: varName
+        character(len = *), optional, intent(in) :: groupName
+        integer(c_int) :: netcdfPutAttArray
+        type(f_c_string_t) :: f_c_string_attName
+        type(f_c_string_t) :: f_c_string_groupName
+        type(f_c_string_t) :: f_c_string_varName
+        type(c_ptr) :: c_attName
+        type(c_ptr) :: c_groupName
+        type(c_ptr) :: c_varName
+        type(c_ptr) :: c_attValue
+        type(f_c_string_t) :: f_c_string_attValue
+
+        if (present(groupName)) then
+            c_groupName = f_c_string_groupName%to_c(groupName)
+        else
+            c_groupName = c_null_ptr
+        end if
+        if (present(varName)) then
+            c_varName = f_c_string_varName%to_c(varName)
+        else
+            c_varName = c_null_ptr
+        end if
+
+        c_attName = f_c_string_attName%to_c(attName)
+
+        select type (attValue)
+        type is (integer(c_int))
+            c_attValue = c_loc(attValue)
+            netcdfPutAttArray = c_netcdfPutAttIntArray(netcdfID, c_attName, c_attValue, attLen, c_varName, c_groupName)
+        class default
+            netcdfPutAttArray = -2
+        end select
+    end function netcdfPutAttArray
+
 
 end module netcdf_cxx_mod


### PR DESCRIPTION
## Summary

This PR adds support for writing **NetCDF integer array attributes** in the C++ NetCDF interface. This functionality is needed to support processing **GNSSRO BUFR files**, which store key metadata as integer arrays.

---

## Motivation

GNSSRO BUFR files contain critical metadata stored as integer arrays. This PR ensures the new C++ interface can correctly write these attributes, supporting GNSSRO BUFR file conversions.

---

## Testing

- All tests in the **`testing/netcdf_attribute_integer_arrays`** branch passed.

## Dependencies

- Support for processing **GNSSRO BUFR** files depend on this PR.
