### PR TITLE
Add support for writing NetCDF double array variables

### DIFF
--- a/obs2ioda-v2/src/cxx/netcdf_variable.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_variable.cc
@@ -133,6 +133,20 @@ namespace Obs2Ioda {
         );
     }
 
+    int netcdfPutVarDouble(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        const double *values
+    ) {
+        return netcdfPutVar(
+            netcdfID,
+            groupName,
+            varName,
+            values
+        );
+    }
+
     int netcdfPutVarChar(
         int netcdfID,
         const char *groupName,

--- a/obs2ioda-v2/src/cxx/netcdf_variable.h
+++ b/obs2ioda-v2/src/cxx/netcdf_variable.h
@@ -60,6 +60,13 @@ namespace Obs2Ioda {
         const float *values
     );
 
+    int netcdfPutVarDouble(
+        int netcdfID,
+        const char *groupName,
+        const char *varName,
+        const double *values
+    );
+
     int netcdfPutVarString(
         int netcdfID,
         const char *groupName,

--- a/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
@@ -213,6 +213,19 @@ module netcdf_cxx_i_mod
         end function c_netcdfPutVarReal
 
         ! See documentation for `c_netcdfPutVarInt`.
+        function c_netcdfPutVarDouble(&
+           netcdfID, groupName, varName, values) &
+           bind(C, name = "netcdfPutVarDouble")
+            import :: c_int
+            import :: c_ptr
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: groupName
+            type(c_ptr), value, intent(in) :: varName
+            type(c_ptr), value, intent(in) :: values
+            integer(c_int) :: c_netcdfPutVarDouble
+        end function c_netcdfPutVarDouble
+
+        ! See documentation for `c_netcdfPutVarInt`.
         function c_netcdfPutVarString(&
                 netcdfID, groupName, varName, values) &
                 bind(C, name = "netcdfPutVarString")

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -1,9 +1,9 @@
 module netcdf_cxx_mod
-    use iso_c_binding, only: c_int, c_ptr, c_null_ptr, c_loc, c_float, c_long
+    use iso_c_binding, only: c_int, c_ptr, c_null_ptr, c_loc, c_float, c_long, c_double
     use f_c_string_t_mod, only: f_c_string_t
     use f_c_string_1D_t_mod, only: f_c_string_1D_t
     use netcdf_cxx_i_mod, only: c_netcdfCreate, c_netcdfClose, c_netcdfAddGroup, c_netcdfAddDim, &
-            c_netcdfAddVar, c_netcdfPutVarInt, c_netcdfPutVarInt64, c_netcdfPutVarReal, c_netcdfPutVarChar, &
+            c_netcdfAddVar, c_netcdfPutVarInt, c_netcdfPutVarInt64, c_netcdfPutVarReal, c_netcdfPutVarDouble, c_netcdfPutVarChar, &
             c_netcdfSetFillInt, c_netcdfSetFillInt64, c_netcdfSetFillReal, c_netcdfSetFillString, &
             c_netcdfPutAttInt, c_netcdfPutAttString
     implicit none
@@ -251,6 +251,11 @@ contains
             c_values = c_loc(values)
             netcdfPutVar = c_netcdfPutVarReal(netcdfID, c_groupName, &
                     c_varName, c_values)
+
+        type is (real(c_double))
+            c_values = c_loc(values)
+            netcdfPutVar = c_netcdfPutVarDouble(netcdfID, c_groupName, &
+               c_varName, c_values)
 
         type is (character(len = *))
             c_values = f_c_string_1D_values%to_c(values)


### PR DESCRIPTION
## Summary

This PR adds support for writing **NetCDF double array variables** in the C++ NetCDF interface. This ensures the interface can handle writing double precision data.


## Testing

- All tests in the **`testing/netcdf_variable_double_arrays`** branch passed.

## Dependencies

- No other PRs depend on this PR.

