### PR TITLE
Declared c_netcdfPutVarChar result variable in c_netcdfPutVarChar int…

### DIFF
--- a/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
@@ -235,7 +235,7 @@ module netcdf_cxx_i_mod
             type(c_ptr), value, intent(in) :: groupName
             type(c_ptr), value, intent(in) :: varName
             type(c_ptr), value, intent(in) :: values
-            integer(c_int) :: c_netcdfPutVarString
+            integer(c_int) :: c_netcdfPutVarChar
         end function c_netcdfPutVarChar
 
         ! c_netcdfSetFillInt:


### PR DESCRIPTION

## Summary

This PR fixes a bug in the Fortran binding for c_netcdfPutVarChar, where the result variable was incorrectly named c_netcdfPutVarString instead of matching the function name, c_netcdfPutVarChar. This mismatch led to undefined behavior when obs2ioda was compiled in release mode, particularly when the return value was used.
