### PR TITLE
Enable hourly IODA file output for GNSSRO obs

### DIFF
--- a/obs2ioda-v2/src/define_mod.f90
+++ b/obs2ioda-v2/src/define_mod.f90
@@ -234,6 +234,12 @@ end type xdata_type
 type(xdata_type), allocatable, dimension(:,:) :: xdata  ! dim 1: number of ob types
                                                         ! dim 2: number of time slots
 
+type output_info_type
+   character(:), allocatable :: output_dir
+   integer :: n_windows
+   integer :: window_length_in_h
+end type
+
 contains
 
 subroutine set_obtype_conv(t29, obtype)
@@ -448,5 +454,14 @@ subroutine set_ahi_obserr(name_inst, nchan, obserrors)
       return
    end if
 end subroutine set_ahi_obserr
+
+subroutine set_output_info(file_output_info, output_dir, n_windows, window_length_in_h)
+   type(output_info_type), intent(out) :: file_output_info
+   character(len = *), intent(in) :: output_dir
+   integer, intent(in) :: n_windows, window_length_in_h
+   file_output_info%output_dir = trim(adjustl(output_dir))
+   file_output_info%n_windows = n_windows
+   file_output_info%window_length_in_h = window_length_in_h
+end subroutine
 
 end module define_mod

--- a/obs2ioda-v2/src/define_mod.f90
+++ b/obs2ioda-v2/src/define_mod.f90
@@ -28,6 +28,7 @@ integer(i_kind), parameter :: write_nc_radiance = 2
 integer(i_kind), parameter :: write_nc_radiance_geo = 3
 character(len=3), parameter :: dtime_min = '-3h'
 character(len=3), parameter :: dtime_max = '+3h'
+integer(i_kind), parameter :: half_bufr_interval = 3  ! corresponds to dtime_min = -3h and dtime_max = +3h
 
 ! variables for defining observation types and met variables each type has
 character(len=nstring), dimension(nobtype) :: obtype_list = &

--- a/obs2ioda-v2/src/main.f90
+++ b/obs2ioda-v2/src/main.f90
@@ -1,7 +1,7 @@
 program obs2ioda
 
 use define_mod, only: write_nc_conv, write_nc_radiance, write_nc_radiance_geo, StrLen, xdata, &
-   ninst
+   ninst, output_info_type, set_output_info
 use kinds, only: i_kind
 use prepbufr_mod, only: read_prepbufr, sort_obs_conv, filter_obs_conv, do_tv_to_ts
 use radiance_mod, only: read_amsua_amsub_mhs, read_airs_colocate_amsua, sort_obs_radiance, &
@@ -56,6 +56,7 @@ integer(i_kind)         :: itmp
 integer(i_kind)         :: itime
 integer(i_kind)         :: superob_halfwidth
 character (len=DateLen14) :: dtime, datetmp
+type(output_info_type) :: file_output_info
 
 
 do_tv_to_ts = .true.
@@ -76,6 +77,8 @@ else
    nfgat = 1
 end if
 
+call set_output_info(file_output_info, outdir, nfgat, hour_fgat)
+
 do ifile = 1, nfile
 
    filename = flist(ifile)
@@ -86,7 +89,7 @@ do ifile = 1, nfile
          write(*,*) 'Warning: ', trim(inpdir)//trim(filename), ' not found for decoding...'
       else
          write(*,*) '--- processing gnssro.bufr ---'
-         call read_write_gnssro(trim(adjustl(inpdir))//trim(adjustl(filename)), trim(adjustl(outdir)), nfgat, hour_fgat)
+         call read_write_gnssro(trim(adjustl(inpdir))//trim(adjustl(filename)), file_output_info)
       end if
    end if
 

--- a/obs2ioda-v2/src/main.f90
+++ b/obs2ioda-v2/src/main.f90
@@ -86,7 +86,7 @@ do ifile = 1, nfile
          write(*,*) 'Warning: ', trim(inpdir)//trim(filename), ' not found for decoding...'
       else
          write(*,*) '--- processing gnssro.bufr ---'
-         call read_write_gnssro(trim(adjustl(inpdir))//trim(adjustl(filename)), trim(adjustl(outdir)), nfgat)
+         call read_write_gnssro(trim(adjustl(inpdir))//trim(adjustl(filename)), trim(adjustl(outdir)), nfgat, hour_fgat)
       end if
    end if
 

--- a/obs2ioda-v2/src/main.f90
+++ b/obs2ioda-v2/src/main.f90
@@ -86,7 +86,7 @@ do ifile = 1, nfile
          write(*,*) 'Warning: ', trim(inpdir)//trim(filename), ' not found for decoding...'
       else
          write(*,*) '--- processing gnssro.bufr ---'
-         call read_write_gnssro(trim(inpdir)//trim(filename), trim(outdir))
+         call read_write_gnssro(trim(adjustl(inpdir))//trim(adjustl(filename)), trim(adjustl(outdir)), nfgat)
       end if
    end if
 


### PR DESCRIPTION
### Description

TYPE: enhancement

This PR enables output of hourly (or other intervals as specified in `hour_fgat`) IODA files for GNSSRO observations, analogous to the other observation types. It also updates global attributes to make the file structure more similar to other observations.

USAGE:
Specify the `-split` option to output IODA files every `hour_fgat` instead of every 6h. For example, assuming `hour_fgat = 1`:
```sh
$ ./obs2ioda_v2 -split gdas.gpsro.t00z.20180415.bufr  # generates 1h IODA files
$ ./obs2ioda_v2 gdas.gpsro.t00z.20180415.bufr  # generates 6h IODA file
```

### Tests conducted

1. Compared 6h IODA file vs. result from main branch. The only differences are in the updated global attributes, as expected:
```sh
$ nccmp -ldmgefs gnssro_obs_2018041500.h5 main/6h/gnssro_obs_2018041500.h5
DIFFER : NUMBER OF GLOBAL ATTRIBUTES : 4 <> 2
DIFFER : NAME OF GLOBAL ATTRIBUTE : nlocs : GLOBAL ATTRIBUTE DOES NOT EXIST IN "main/6h/gnssro_obs_2018041500.h5"
DIFFER : NAME OF GLOBAL ATTRIBUTE : min_datetime : GLOBAL ATTRIBUTE DOES NOT EXIST IN "main/6h/gnssro_obs_2018041500.h5"
DIFFER : NAME OF GLOBAL ATTRIBUTE : max_datetime : GLOBAL ATTRIBUTE DOES NOT EXIST IN "main/6h/gnssro_obs_2018041500.h5"
DIFFER : NAME OF GLOBAL ATTRIBUTE : date_time : GLOBAL ATTRIBUTE DOES NOT EXIST IN gnssro_obs_2018041500.h5
```
2. Conducted 3dEnvar DA runs with hourly observation files.
