### PR TITLE
Add support for single-precision floating point array attributes.

### DIFF
--- a/obs2ioda-v2/src/cxx/netcdf_attribute.cc
+++ b/obs2ioda-v2/src/cxx/netcdf_attribute.cc
@@ -55,6 +55,16 @@ namespace Obs2Ioda {
         );
     }
 
+    int netcdfPutAttRealArray(
+        int netcdfID, const char *attName, const float *attValue,
+        const int attLen, const char *varName, const char *groupName
+    ) {
+        return netcdfPutAtt(
+            netcdfID, attName, attValue, varName, groupName,
+            netCDF::NcType(netCDF::ncFloat), attLen
+        );
+    }
+
     int netcdfPutAttInt(
         int netcdfID, const char *attName, const int *attValue,
         const char *varName, const char *groupName

--- a/obs2ioda-v2/src/cxx/netcdf_attribute.h
+++ b/obs2ioda-v2/src/cxx/netcdf_attribute.h
@@ -47,6 +47,11 @@ namespace Obs2Ioda {
         int attLen, const char *varName, const char *groupName
     );
 
+    int netcdfPutAttRealArray(
+        int netcdfID, const char *attName, const float *attValue,
+        int attLen, const char *varName, const char *groupName
+    );
+
     int netcdfPutAttString(
         int netcdfID, const char *attName, const char *attValue,
         const char *varName, const char *groupName

--- a/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_i_mod.f90
@@ -377,6 +377,20 @@ module netcdf_cxx_i_mod
             integer(c_int) :: c_netcdfPutAttIntArray
         end function c_netcdfPutAttIntArray
 
+        function c_netcdfPutAttRealArray(&
+                netcdfID, attName, attValue, attLen, varName, groupName) &
+                bind(C, name = "netcdfPutAttRealArray")
+            import :: c_int
+            import :: c_ptr
+            integer(c_int), value, intent(in) :: netcdfID
+            type(c_ptr), value, intent(in) :: attName
+            type(c_ptr), value, intent(in) :: attValue
+            integer(c_int), value, intent(in) :: attLen
+            type(c_ptr), value, intent(in) :: varName
+            type(c_ptr), value, intent(in) :: groupName
+            integer(c_int) :: c_netcdfPutAttRealArray
+        end function c_netcdfPutAttRealArray
+
         ! See documentation for `c_netcdfPutAttInt`.
         function c_netcdfPutAttString(&
                 netcdfID, attName, attValue, varName, groupName) &

--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -5,7 +5,7 @@ module netcdf_cxx_mod
     use netcdf_cxx_i_mod, only: c_netcdfCreate, c_netcdfClose, c_netcdfAddGroup, c_netcdfAddDim, &
             c_netcdfAddVar, c_netcdfPutVarInt, c_netcdfPutVarInt64, c_netcdfPutVarReal, c_netcdfPutVarDouble, c_netcdfPutVarChar, &
             c_netcdfSetFillInt, c_netcdfSetFillInt64, c_netcdfSetFillReal, c_netcdfSetFillString, &
-            c_netcdfPutAttInt, c_netcdfPutAttString, c_netcdfPutAttIntArray
+            c_netcdfPutAttInt, c_netcdfPutAttString, c_netcdfPutAttIntArray, c_netcdfPutAttRealArray
     implicit none
     public
 
@@ -465,6 +465,9 @@ contains
         type is (integer(c_int))
             c_attValue = c_loc(attValue)
             netcdfPutAttArray = c_netcdfPutAttIntArray(netcdfID, c_attName, c_attValue, attLen, c_varName, c_groupName)
+        type is (real(c_float))
+            c_attValue = c_loc(attValue)
+            netcdfPutAttArray = c_netcdfPutAttRealArray(netcdfID, c_attName, c_attValue, attLen, c_varName, c_groupName)
         class default
             netcdfPutAttArray = -2
         end select


### PR DESCRIPTION
### Description
TYPE: enhancement

This PR adds the functionality to write single-precision floating point array attributes. This is required to generate GNSSRO IODA files.

### Tests conducted
Wrote one single-precision floating point array attribute to file and confirmed that it was equivalent to the attribute generated by the fortran netcdf interface.