### PR TITLE
Change Scan Position Variable Type from Float to Int for IODA v2 Compliance

### DIFF
--- a/obs2ioda-v2/src/ncio_mod.f90
+++ b/obs2ioda-v2/src/ncio_mod.f90
@@ -249,7 +249,7 @@ subroutine write_obs (filedate, write_opt, outdir, itim)
                   [dim2_name, dim1_name], "MetaData")
             else
                if (ncname == 'scan_position') then
-                  status = netcdfAddVar(netcdfID, ncname, type_sen_info(i), 1, &
+                  status = netcdfAddVar(netcdfID, ncname, nf90_int, 1, &
                      [dim1_name], "MetaData", fillValue = -999)
                else
                   status = netcdfAddVar(netcdfID, ncname, type_sen_info(i), 1, &

--- a/obs2ioda-v2/src/ncio_mod.f90
+++ b/obs2ioda-v2/src/ncio_mod.f90
@@ -367,7 +367,6 @@ subroutine write_obs (filedate, write_opt, outdir, itim)
                else
                   status = netcdfPutVar(netcdfID, ncname, xdata(ityp, itim)%xseninfo_float(:, i), "MetaData")
                end if
-               status = netcdfPutVar(netcdfID, ncname, xdata(ityp, itim)%xseninfo_float(:, i), "MetaData")
             else if (type_sen_info(i) == nf90_char) then
                status = netcdfPutVar(netcdfID, ncname, xdata(ityp, itim)%xseninfo_char(:, i), "MetaData")
             end if

--- a/obs2ioda-v2/src/ncio_mod.f90
+++ b/obs2ioda-v2/src/ncio_mod.f90
@@ -57,7 +57,7 @@ subroutine write_obs (filedate, write_opt, outdir, itim)
    character(len=nstring)                :: ncname
    integer(i_kind)                       :: ncfileid
    integer(i_kind)                       :: ntype
-   integer(i_kind)                       :: i, ityp, ivar, ii, iv, jj
+   integer(i_kind)                       :: i, ityp, ivar, ii, iv, jj, scan_position_idx
    integer(i_kind)                       :: idim, dim1, dim2
    character(len=nstring),   allocatable :: str_nstring(:)
    character(len=ndatetime), allocatable :: str_ndatetime(:)
@@ -73,6 +73,7 @@ subroutine write_obs (filedate, write_opt, outdir, itim)
    logical :: nchans_nvars_flag
    character(len = nstring) :: dim1_name
    character(len = nstring) :: dim2_name
+   integer(i_kind), allocatable, dimension(:, :) :: scan_position_values
 
    if ( write_opt == write_nc_conv ) then
       ntype = nobtype
@@ -247,12 +248,17 @@ subroutine write_obs (filedate, write_opt, outdir, itim)
                status = netcdfAddVar(netcdfID, ncname, type_sen_info(i), 2, &
                   [dim2_name, dim1_name], "MetaData")
             else
-               status = netcdfAddVar(netcdfID, ncname, type_sen_info(i), 1, &
-                  [dim1_name], "MetaData")
+               if (ncname == 'scan_position') then
+                  status = netcdfAddVar(netcdfID, ncname, type_sen_info(i), 1, &
+                     [dim1_name], "MetaData", fillValue = -999)
+               else
+                  status = netcdfAddVar(netcdfID, ncname, type_sen_info(i), 1, &
+                     [dim1_name], "MetaData")
+               end if
             end if
             if (type_sen_info(i) == NF90_INT) then
                status = netcdfSetFill(netcdfID, ncname, 1, -999, "MetaData")
-            else if (type_sen_info(i) == NF90_FLOAT) then
+            else if (type_sen_info(i) == NF90_FLOAT .and. ncname /= "scan_position") then
                status = netcdfSetFill(netcdfID, ncname, 1, -999.0, "MetaData")
             end if
          end do ! nsen_info
@@ -346,11 +352,20 @@ subroutine write_obs (filedate, write_opt, outdir, itim)
       end do var_info_loop
 
       if ( write_opt == write_nc_radiance .or. write_opt == write_nc_radiance_geo ) then
+         allocate(scan_position_values(xdata(ityp, itim)%nlocs, nsen_info))
          do i = 1, nsen_info
             ncname = trim(name_sen_info(i))
             if (type_sen_info(i) == nf90_int) then
                status = netcdfPutVar(netcdfID, ncname, xdata(ityp, itim)%xseninfo_int(:, i), "MetaData")
             else if (type_sen_info(i) == nf90_float) then
+               if (trim(ncname) == "scan_position") then
+                  do scan_position_idx = 1, xdata(ityp, itim)%nlocs
+                     scan_position_values(scan_position_idx, i) = int(xdata(ityp, itim)%xseninfo_float(scan_position_idx, i), i_kind)
+                  end do
+                  status = netcdfPutVar(netcdfID, ncname, scan_position_values(:, i), "MetaData")
+               else
+                  status = netcdfPutVar(netcdfID, ncname, xdata(ityp, itim)%xseninfo_float(:, i), "MetaData")
+               end if
                status = netcdfPutVar(netcdfID, ncname, xdata(ityp, itim)%xseninfo_float(:, i), "MetaData")
             else if (type_sen_info(i) == nf90_char) then
                status = netcdfPutVar(netcdfID, ncname, xdata(ityp, itim)%xseninfo_char(:, i), "MetaData")
@@ -362,6 +377,7 @@ subroutine write_obs (filedate, write_opt, outdir, itim)
          end if
          deallocate (ichan)
          deallocate (obserr)
+         deallocate (scan_position_values)
       end if ! write_nc_radiance
 
       status = netcdfClose(netcdfID)


### PR DESCRIPTION
#### **Summary:**  
This PR updates the scan position variable type from `float` to `int` to ensure compliance with the IODA v2 format.  

#### **Changes:**  
- Modified the scan position variable type from `float` to `int`.  

#### **Motivation:**  
- IODA v2 requires scan position to be stored as an integer rather than a floating-point value.  
