### PR TITLE
Make `-mcmodel=medium` GNU/Linux-Specific to Support macOS Compilation

### DIFF
--- a/cmake/Obs2Ioda_CompilerFlags.cmake
+++ b/cmake/Obs2Ioda_CompilerFlags.cmake
@@ -1,8 +1,13 @@
 # Set Fortran compiler flags specific to the GNU Compiler
 # -ffree-line-length-none: Remove the limit on the length of lines in the source file
-# -mcmodel=medium: Allow for larger datasets in memory
 set(FORTRAN_COMPILER_GNU_FLAGS
-    $<$<COMPILE_LANGUAGE:Fortran>:-ffree-line-length-none -mcmodel=medium>
+    $<$<COMPILE_LANGUAGE:Fortran>:-ffree-line-length-none>
+)
+
+# Set Fortran compiler flags specific to the GNU Compiler and Linux OS.
+# -mcmodel=medium: Allow for larger datasets in memory
+set(FORTRAN_COMPILER_GNU_LINUX_FLAGS
+        $<$<COMPILE_LANGUAGE:Fortran>:-mcmodel=medium>
 )
 
 # Set Debugging Fortran compiler flags specific to the GNU Compiler

--- a/cmake/Obs2Ioda_Functions.cmake
+++ b/cmake/Obs2Ioda_Functions.cmake
@@ -30,6 +30,11 @@ function(obs2ioda_fortran_library target public_link_libraries)
         list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
              ${FORTRAN_COMPILER_GNU_FLAGS}
         )
+        if (CMAKE_SYSTEM_NAME MATCHES Linux)
+            list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
+                 ${FORTRAN_COMPILER_GNU_LINUX_FLAGS}
+            )
+        endif ()
         if (CMAKE_BUILD_TYPE MATCHES Debug)
             list(APPEND OBS2IODA_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
                  ${FORTRAN_COMPILER_GNU_DEBUG_FLAGS}


### PR DESCRIPTION
This PR moves `-mcmodel=medium` into a separate compiler flag list that is only added when using GNU compilers on Linux. This allows the library to compile on macOS with GNU compilers, which previously failed due to `-mcmodel` being a Linux-specific flag.