### PR TITLE
Add yaml-cpp as a Dependency via CMake FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 
 include("${CMAKE_SOURCE_DIR}/cmake/Obs2Ioda_Functions.cmake")
 enable_testing()
+include(FetchContent)
 # Define the project
 project(obs2ioda LANGUAGES Fortran CXX)
 

--- a/obs2ioda-v2/src/cxx/CMakeLists.txt
+++ b/obs2ioda-v2/src/cxx/CMakeLists.txt
@@ -1,3 +1,10 @@
+FetchContent_Declare(
+        yaml-cpp
+        GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
+        GIT_TAG master
+)
+FetchContent_MakeAvailable(yaml-cpp)
+
 set(obs2ioda_cxx_SOURCES
     netcdf_error.cc
     netcdf_file.cc

--- a/obs2ioda-v2/src/cxx/CMakeLists.txt
+++ b/obs2ioda-v2/src/cxx/CMakeLists.txt
@@ -1,7 +1,7 @@
 FetchContent_Declare(
         yaml-cpp
         GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-        GIT_TAG master
+        GIT_TAG 0.8.0
 )
 FetchContent_MakeAvailable(yaml-cpp)
 


### PR DESCRIPTION
### Description:  
This PR integrates `yaml-cpp` into the CMake build system using `FetchContent`. This allows `yaml-cpp` to be automatically downloaded and built as part of the project's build process, eliminating the need for external installations.
