### PR TITLE
Fix Intel compilation error due to non-standard `c_loc` usage

### DIFF
--- a/obs2ioda-v2/src/netcdf_cxx_mod.f90
+++ b/obs2ioda-v2/src/netcdf_cxx_mod.f90
@@ -224,7 +224,7 @@ contains
     function netcdfPutVar(netcdfID, varName, values, groupName)
         integer(c_int), value, intent(in) :: netcdfID
         character(len = *), intent(in) :: varName
-        class(*), dimension(:), intent(in) :: values
+        class(*), dimension(:), target, intent(in) :: values
         character(len = *), optional, intent(in) :: groupName
         integer(c_int) :: netcdfPutVar
         type(f_c_string_t) :: f_c_string_groupName
@@ -300,7 +300,7 @@ contains
         integer(c_int), value, intent(in) :: netcdfID
         character(len = *), intent(in) :: varName
         integer(c_int), value, intent(in) :: fillMode
-        class(*), intent(in) :: fillValue
+        class(*), target, intent(in) :: fillValue
         character(len = *), optional, intent(in) :: groupName
         integer(c_int) :: netcdfSetFill
         type(f_c_string_t) :: f_c_string_groupName
@@ -366,7 +366,7 @@ contains
     function netcdfPutAtt(netcdfID, attName, attValue, varName, groupName)
         integer(c_int), value, intent(in) :: netcdfID
         character(len = *), intent(in) :: attName
-        class(*), intent(in) :: attValue
+        class(*), target, intent(in) :: attValue
         character(len = *), optional, intent(in) :: varName
         character(len = *), optional, intent(in) :: groupName
         integer(c_int) :: netcdfPutAtt
@@ -435,7 +435,7 @@ contains
     function netcdfPutAttArray(netcdfID, attName, attValue, attLen, varName, groupName)
         integer(c_int), value, intent(in) :: netcdfID
         character(len = *), intent(in) :: attName
-        class(*), intent(in) :: attValue(:)
+        class(*), target, intent(in) :: attValue(:)
         integer(c_int), intent(in), value :: attLen
         character(len = *), optional, intent(in) :: varName
         character(len = *), optional, intent(in) :: groupName


### PR DESCRIPTION
This PR updates `netcdf_cxx_mod` to ensure Fortran standard compliance and resolve compilation failures with Intel compilers.

#### Problem
Throughout `netcdf_cxx_mod`, variables passed to the Fortran intrinsic `c_loc` were **not declared with the `target` attribute**, which is a requirement of the Fortran standard. While GNU compilers allow this non-compliant usage, Intel compilers correctly raise errors, causing the build to fail when using `ifort` or `ifx`.

#### Fix
All variables passed to `c_loc` in `netcdf_cxx_mod` have been updated to include the `target` attribute. This ensures the code conforms to the Fortran standard and is portable across multiple compiler suites.

#### Notes
- No changes to logic or behavior — purely a fix to variable declarations
- Fix confirmed with both GNU and Intel compiler toolchains