### PR TITLE
Add global Location dimension variable to `write_gnssro_data` subroutine

### DIFF
--- a/obs2ioda-v2/src/gnssro_mod.f90
+++ b/obs2ioda-v2/src/gnssro_mod.f90
@@ -451,6 +451,7 @@ contains
       dim_name = 'nlocs'
       call check(netcdfAddDim(ncid, dim_name, ndata, dim_id))
       call check(netcdfPutAtt(ncid, dim_name, ndata))
+      call check(netcdfAddVar(ncid, trim(dim_name), NF90_INT, 1, [trim(dim_name)]))
 
       ! Write other global attributes (again analogous to netcdf_mod)
       idx_min_time = minloc(gnssro_data%epochtime, mask = is_in_window, dim = 1)


### PR DESCRIPTION
### Summary

This PR updates the `write_gnssro_data` subroutine to write a global `Location` dimension variable.

### Changes

- Added a call to `netcdfAddVar` to define a global variable for the `Location` dimension in `gnssro` output files.

### Motivation

The latest IODA format requires an explicit global variable for each dimension, including `Location`. This update ensures that `gnssro` files written by this module remain compatible with the latest version of `IODA`.






