### PR TITLE
Replace Global Instance of `IodaObsSchema` with Singleton Class `IodaObsSchemaMap`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 
 .DS_Store
 .DS_Store
-*/pycache
+**/__pycache__
 test/validation/data
 test/validation/data.tar.gz
 test/validation/FilePathConfig.py

--- a/obs2ioda-v3/README.md
+++ b/obs2ioda-v3/README.md
@@ -34,7 +34,7 @@ The `obs2ioda-v3` executable will reside in the `bin` directory within the build
 
 ### Running the Obs2Ioda Test Suite
 #### Running the Unit Test Suite
-1. **Run the unit test suite** using `ctest`. To see detailed output and the list of tests being executed, add the `--verbose` flag:
+1. **Run the unit test suite** from the `obs2ioda` build directory. To see detailed output and the list of tests being executed, add the `--verbose` flag:
    ```bash
    ctest --verbose
    ```

--- a/obs2ioda-v3/src/cxx/CMakeLists.txt
+++ b/obs2ioda-v3/src/cxx/CMakeLists.txt
@@ -13,6 +13,7 @@ set(obs2ioda_cxx_SOURCES
     netcdf_variable.cc
     netcdf_attribute.cc
     ioda_obs_schema.cc
+        ioda_obs_schema_map/ioda_obs_schema_map.cc
 )
 set(obs2ioda_cxx_LIBRARIES
     NetCDF::NetCDF_CXX
@@ -25,3 +26,4 @@ set(obs2ioda_cxx_INCLUDE_DIRS
 add_library(obs2ioda_cxx SHARED ${obs2ioda_cxx_SOURCES})
 target_compile_definitions(obs2ioda_cxx PUBLIC OBS2IODA_ROOT_DIR="${CMAKE_SOURCE_DIR}")
 obs2ioda_cxx_library(obs2ioda_cxx "${obs2ioda_cxx_INCLUDE_DIRS}" "${obs2ioda_cxx_LIBRARIES}")
+add_subdirectory("ioda_obs_schema_map")

--- a/obs2ioda-v3/src/cxx/ioda_obs_schema_map/CMakeLists.txt
+++ b/obs2ioda-v3/src/cxx/ioda_obs_schema_map/CMakeLists.txt
@@ -1,0 +1,18 @@
+include("/Users/astokely/projects/obs2ioda/test/cmake/Obs2Ioda_Test_Functions.cmake")
+set(ioda_obs_schema_test_SOURCES
+        "ioda_obs_schema_map.test.cc"
+)
+set(ioda_obs_schema_test_INCLUDE_DIRECTORIES
+        "../"
+        "${CMAKE_BINARY_DIR}/generated"
+)
+set(ioda_obs_schema_test_LIBRARY_DEPENDENCIES
+        obs2ioda_cxx
+        yaml-cpp::yaml-cpp
+        GTest::gtest_main
+)
+add_cxx_ctest(ioda_obs_schema_test
+        "${ioda_obs_schema_test_SOURCES}"
+        "${ioda_obs_schema_test_INCLUDE_DIRECTORIES}"
+        "${ioda_obs_schema_test_LIBRARY_DEPENDENCIES}"
+)

--- a/obs2ioda-v3/src/cxx/ioda_obs_schema_map/ioda_obs_schema_map.cc
+++ b/obs2ioda-v3/src/cxx/ioda_obs_schema_map/ioda_obs_schema_map.cc
@@ -1,0 +1,43 @@
+#include "ioda_obs_schema_map.h"
+
+#include <ncException.h>
+
+
+namespace Obs2Ioda {
+
+    IodaObsSchemaMap &IodaObsSchemaMap::getInstance() {
+        static IodaObsSchemaMap instance;
+        return instance;
+    }
+
+    void IodaObsSchemaMap::addIodaObsSchema(int iodaObsSchemaID,
+        const std::shared_ptr<IodaObsSchema> &iodaObsSchema) {
+        iodaObsSchemaMap[iodaObsSchemaID] = iodaObsSchema;
+    }
+
+    std::shared_ptr<IodaObsSchema> IodaObsSchemaMap::getIodaObsSchema(const int iodaObsSchemaID) {
+        const auto it = iodaObsSchemaMap.find(iodaObsSchemaID);
+        if (it == iodaObsSchemaMap.end()) {
+            throw netCDF::exceptions::NcBadId(
+                ("IodaObsSchema ID not found in the IodaObsSchema map: " +
+                 std::to_string(iodaObsSchemaID)).c_str(),
+               __FILE__,
+               __LINE__
+           );
+        }
+        return it->second;
+    }
+
+    void IodaObsSchemaMap::removeIodaObsSchema(int iodaObsSchemaID) {
+        auto iodaObsSchemaIterator = this->iodaObsSchemaMap.find(iodaObsSchemaID);
+        if (iodaObsSchemaIterator == this->iodaObsSchemaMap.end()) {
+            throw netCDF::exceptions::NcBadId(
+                ("IodaObsSchema ID not found in the IodaObsSchema map: " +
+                 std::to_string(iodaObsSchemaID)).c_str(),
+               __FILE__,
+               __LINE__
+           );
+        }
+        this->iodaObsSchemaMap.erase(iodaObsSchemaIterator);
+    }
+}

--- a/obs2ioda-v3/src/cxx/ioda_obs_schema_map/ioda_obs_schema_map.h
+++ b/obs2ioda-v3/src/cxx/ioda_obs_schema_map/ioda_obs_schema_map.h
@@ -1,0 +1,40 @@
+#ifndef OBS2IODA_IODA_OBS_SCHEMA_FILE_MAP_H
+#define OBS2IODA_IODA_OBS_SCHEMA_FILE_MAP_H
+
+#include "ioda_obs_schema.h"
+
+namespace Obs2Ioda {
+    class IodaObsSchemaMap {
+    public:
+        static IodaObsSchemaMap &getInstance();
+
+        IodaObsSchemaMap(
+            const IodaObsSchemaMap &
+        ) = delete;
+
+        IodaObsSchemaMap &operator=(
+            const IodaObsSchemaMap &
+        ) = delete;
+
+        void addIodaObsSchema(
+            int iodaObsSchemaID,
+            const std::shared_ptr<IodaObsSchema> &iodaObsSchema
+        );
+
+        std::shared_ptr<IodaObsSchema> getIodaObsSchema(
+            int iodaObsSchemaID
+        );
+
+        void removeIodaObsSchema(
+            int iodaObsSchemaID
+        );
+
+    private:
+        IodaObsSchemaMap() = default;
+
+        std::unordered_map<int, std::shared_ptr<IodaObsSchema> >
+        iodaObsSchemaMap;
+    };
+} // namespace Obs2Ioda
+
+#endif // OBS2IODA_IODA_OBS_SCHEMA_FILE_MAP_H

--- a/obs2ioda-v3/src/cxx/ioda_obs_schema_map/ioda_obs_schema_map.test.cc
+++ b/obs2ioda-v3/src/cxx/ioda_obs_schema_map/ioda_obs_schema_map.test.cc
@@ -5,9 +5,6 @@
 #include "ioda_obs_schema_map.h"
 #include "ioda_obs_schema.h"
 
-namespace Obs2Ioda {
-    class IodaObsSchemaMap;
-}
 
 TEST(IodaObsSchemaMap, IodaObsSchemaMapAddFile) {
     int iodaObsSchemaID = 1;

--- a/obs2ioda-v3/src/cxx/ioda_obs_schema_map/ioda_obs_schema_map.test.cc
+++ b/obs2ioda-v3/src/cxx/ioda_obs_schema_map/ioda_obs_schema_map.test.cc
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include <ncException.h>
+
+#include "ioda_obs_schema_map.h"
+#include "ioda_obs_schema.h"
+
+namespace Obs2Ioda {
+    class IodaObsSchemaMap;
+}
+
+TEST(IodaObsSchemaMap, IodaObsSchemaMapAddFile) {
+    int iodaObsSchemaID = 1;
+    const auto iodaObsSchema = std::make_shared<IodaObsSchema>(
+        YAML::LoadFile(Obs2Ioda::IODA_SCHEMA_YAML)
+        );
+    Obs2Ioda::IodaObsSchemaMap::getInstance().addIodaObsSchema(
+        iodaObsSchemaID,
+        iodaObsSchema
+    );
+    EXPECT_NO_THROW(Obs2Ioda::IodaObsSchemaMap::getInstance().getIodaObsSchema(iodaObsSchemaID));
+    EXPECT_NO_THROW(Obs2Ioda::IodaObsSchemaMap::getInstance().removeIodaObsSchema(iodaObsSchemaID));
+    EXPECT_THROW(Obs2Ioda::IodaObsSchemaMap::getInstance().getIodaObsSchema(iodaObsSchemaID), netCDF::exceptions::NcBadId);
+}
+
+TEST(IodaObsSchemaMap, IodaObsSchemaMapThrow) {
+    int iodaObsSchemaID = 1;
+    EXPECT_THROW(Obs2Ioda::IodaObsSchemaMap::getInstance().getIodaObsSchema(iodaObsSchemaID), netCDF::exceptions::NcBadId);
+    EXPECT_THROW(Obs2Ioda::IodaObsSchemaMap::getInstance().removeIodaObsSchema(iodaObsSchemaID), netCDF::exceptions::NcBadId);
+}
+
+int main(int argc,
+         char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/obs2ioda-v3/src/cxx/netcdf_attribute.cc
+++ b/obs2ioda-v3/src/cxx/netcdf_attribute.cc
@@ -1,6 +1,7 @@
 #include "netcdf_attribute.h"
 #include "netcdf_file.h"
 #include "netcdf_error.h"
+#include "ioda_obs_schema_map/ioda_obs_schema_map.h"
 
 namespace Obs2Ioda {
     template<typename T> int netcdfPutAtt(
@@ -10,6 +11,7 @@ namespace Obs2Ioda {
     ) {
         try {
             auto file = FileMap::getInstance().getFile(netcdfID);
+            const auto iodaSchema = IodaObsSchemaMap::getInstance().getIodaObsSchema(netcdfID);
             std::shared_ptr<netCDF::NcGroup> group = (groupName && *
                 groupName)
                 ? std::make_shared<netCDF::NcGroup>(
@@ -17,7 +19,7 @@ namespace Obs2Ioda {
                 ) : file;
 
             if (varName) {
-                auto iodaVarName = iodaSchema.getVariable(varName)->getValidName();
+                auto iodaVarName = iodaSchema->getVariable(varName)->getValidName();
                 auto var = group->getVar(iodaVarName);
                 if (netcdfDataType == netCDF::ncString) {
                     var.putAtt(

--- a/obs2ioda-v3/src/cxx/netcdf_dimension.cc
+++ b/obs2ioda-v3/src/cxx/netcdf_dimension.cc
@@ -1,6 +1,7 @@
 #include "netcdf_dimension.h"
 #include "netcdf_file.h"
 #include "netcdf_error.h"
+#include "ioda_obs_schema_map/ioda_obs_schema_map.h"
 
 namespace Obs2Ioda {
     int netcdfAddDim(
@@ -12,13 +13,14 @@ namespace Obs2Ioda {
     ) {
         try {
             const auto file = FileMap::getInstance().getFile(netcdfID);
+            const auto iodaSchema = IodaObsSchemaMap::getInstance().getIodaObsSchema(netcdfID);
             const auto group = !groupName
                                    ? file
                                    : std::make_shared<
                                        netCDF::NcGroup>(
                                        file->getGroup(
                                            groupName));
-            auto iodaDimName = iodaSchema.getDimension(dimName)->getValidName();
+            auto iodaDimName = iodaSchema->getDimension(dimName)->getValidName();
             auto dim = group->addDim(iodaDimName, len);
             *dimID = dim.getId();
             return 0;

--- a/obs2ioda-v3/src/cxx/netcdf_file.cc
+++ b/obs2ioda-v3/src/cxx/netcdf_file.cc
@@ -87,6 +87,7 @@ namespace Obs2Ioda {
         try {
             FileMap::getInstance().getFile(netcdfID)->close();
             FileMap::getInstance().removeFile(netcdfID);
+            IodaObsSchemaMap::getInstance().removeIodaObsSchema(netcdfID);
             return 0;
         } catch (netCDF::exceptions::NcException &e) {
             return netcdfErrorMessage(

--- a/obs2ioda-v3/src/cxx/netcdf_file.cc
+++ b/obs2ioda-v3/src/cxx/netcdf_file.cc
@@ -1,10 +1,10 @@
 #include "netcdf_file.h"
 #include "netcdf_error.h"
 #include <memory>
+#include <ioda_obs_schema_map/ioda_obs_schema_map.h>
 
 
 namespace Obs2Ioda {
-    IodaObsSchema iodaSchema(YAML::LoadFile(IODA_SCHEMA_YAML));
 
     FileMap &FileMap::getInstance() {
         static FileMap instance;
@@ -68,7 +68,11 @@ namespace Obs2Ioda {
                 *netcdfID,
                 file
             );
-
+            const auto iodaObsSchema = std::make_shared<IodaObsSchema>(YAML::LoadFile(IODA_SCHEMA_YAML));
+            IodaObsSchemaMap::getInstance().addIodaObsSchema(
+                *netcdfID,
+                iodaObsSchema
+            );
             return 0;
         } catch (netCDF::exceptions::NcException &e) {
             return netcdfErrorMessage(

--- a/obs2ioda-v3/src/cxx/netcdf_file.h
+++ b/obs2ioda-v3/src/cxx/netcdf_file.h
@@ -7,7 +7,6 @@
 #include "ioda_obs_schema.h"
 
 namespace Obs2Ioda {
-    extern IodaObsSchema iodaSchema;
     /**
      * @class FileMap
      * @brief Singleton class for managing a mapping of NetCDF file IDs to file objects.

--- a/obs2ioda-v3/src/cxx/netcdf_group.cc
+++ b/obs2ioda-v3/src/cxx/netcdf_group.cc
@@ -1,6 +1,7 @@
 #include "netcdf_group.h"
 #include "netcdf_file.h"
 #include "netcdf_error.h"
+#include "ioda_obs_schema_map/ioda_obs_schema_map.h"
 
 namespace Obs2Ioda {
     int netcdfAddGroup(
@@ -10,6 +11,7 @@ namespace Obs2Ioda {
     ) {
         try {
             auto file = FileMap::getInstance().getFile(netcdfID);
+            const auto iodaSchema = IodaObsSchemaMap::getInstance().getIodaObsSchema(netcdfID);
             // Use the root group (the netCDF::NcFile object) if parentGroupName is null;
             // otherwise, use the group with the specified name.
             const auto parentGroup = !parentGroupName
@@ -18,7 +20,7 @@ namespace Obs2Ioda {
                                              netCDF::NcGroup>(
                                              file->getGroup(
                                                  parentGroupName));
-            auto iodaGroupName = iodaSchema.getGroup(groupName)->getValidName();
+            auto iodaGroupName = iodaSchema->getGroup(groupName)->getValidName();
             const auto group = parentGroup->addGroup(iodaGroupName);
             return 0;
         } catch (netCDF::exceptions::NcException &e) {

--- a/obs2ioda-v3/src/cxx/netcdf_variable.cc
+++ b/obs2ioda-v3/src/cxx/netcdf_variable.cc
@@ -3,6 +3,7 @@
 #include "netcdf_error.h"
 #include <algorithm>
 #include <cstring>
+#include "ioda_obs_schema_map/ioda_obs_schema_map.h"
 
 namespace Obs2Ioda {
 
@@ -27,18 +28,19 @@ namespace Obs2Ioda {
     ) {
         try {
             auto file = FileMap::getInstance().getFile(netcdfID);
+            const auto iodaSchema = IodaObsSchemaMap::getInstance().getIodaObsSchema(netcdfID);
             const auto group = !groupName
                                    ? file
                                    : std::make_shared<
                                        netCDF::NcGroup>(
                                        file->getGroup(
-                                           iodaSchema.getGroup(groupName)->getValidName()));
+                                           iodaSchema->getGroup(groupName)->getValidName()));
             std::vector<netCDF::NcDim> dims;
             dims.reserve(numDims);
             for (int i = 0; i < numDims; i++) {
-                dims.push_back(file->getDim(iodaSchema.getDimension(dimNames[i])->getValidName()));;
+                dims.push_back(file->getDim(iodaSchema->getDimension(dimNames[i])->getValidName()));;
             }
-            auto iodaVarName = iodaSchema.getVariable(varName)->getValidName();
+            auto iodaVarName = iodaSchema->getVariable(varName)->getValidName();
             auto var = group->addVar(
                 iodaVarName,
                 netCDF::NcType(netcdfDataType),
@@ -63,13 +65,14 @@ namespace Obs2Ioda {
     ) {
         try {
             auto file = FileMap::getInstance().getFile(netcdfID);
+            const auto iodaSchema = IodaObsSchemaMap::getInstance().getIodaObsSchema(netcdfID);
             const auto group = !groupName
                                    ? file
                                    : std::make_shared<
                                        netCDF::NcGroup>(
                                        file->getGroup(
-                                           iodaSchema.getGroup(groupName)->getValidName()));
-            auto iodaVarName = iodaSchema.getVariable(varName)->getValidName();
+                                           iodaSchema->getGroup(groupName)->getValidName()));
+            auto iodaVarName = iodaSchema->getVariable(varName)->getValidName();
             const auto var = group->getVar(iodaVarName);
             auto varType = var.getType();
             // Special handling for char arrays
@@ -187,13 +190,14 @@ namespace Obs2Ioda {
     ) {
         try {
             auto file = FileMap::getInstance().getFile(netcdfID);
+            const auto iodaSchema = IodaObsSchemaMap::getInstance().getIodaObsSchema(netcdfID);
             const auto group = !groupName
                                    ? file
                                    : std::make_shared<
                                        netCDF::NcGroup>(
                                        file->getGroup(
-                                           iodaSchema.getGroup(groupName)->getValidName()));
-            auto iodaVarName = iodaSchema.getVariable(varName)->getValidName();
+                                           iodaSchema->getGroup(groupName)->getValidName()));
+            auto iodaVarName = iodaSchema->getVariable(varName)->getValidName();
             auto var = group->getVar(iodaVarName);
             var.setFill(
                 fillMode,

--- a/test/validation/test_obs2ioda.py
+++ b/test/validation/test_obs2ioda.py
@@ -34,8 +34,8 @@ def format_netcdf_assert_msg(file: str, group: str, variable: str, detail: str,
     return (
         f"[NetCDF Mismatch] File: '{file}' | Group: '{group}' | Variable: '{variable}'\n"
         f"Reason: {detail}\n"
-        f"Reference: {ref_val}\n"
-        f"Test:      {test_val}"
+        f"Expected: {ref_val}\n"
+        f"Actual:      {test_val}"
     )
 
 


### PR DESCRIPTION
**Summary:**

This PR introduces a new singleton class, `IodaObsSchemaMap`, which manages the global `IodaObsSchema` instance on a per-NetCDF-file basis. This change replaces the previous use of a raw global variable and provides several important benefits.

Encapsulating the schema in a singleton improves safety by avoiding undefined behavior associated with global state. It also allows `IodaObsSchema` setup methods to be called after instantiation, which was not possible with a purely global instance. This behavior will be necessary for supporting V1 to V3 IODA format conversion, where schema configuration may depend on version-specific context.

**Testing:**

All unit and validation tests pass:

[Unit test log](https://github.com/user-attachments/files/20260071/log.ctest.txt)
[Validation test log](https://github.com/user-attachments/files/20260068/log.pytest.txt)
