### PR TITLE
Changed the output_dir length to 512 in the write_goes_abi_ioda_v3 test.

### DIFF
--- a/test/validation/write_goes_abi_ioda_v3.test.f90
+++ b/test/validation/write_goes_abi_ioda_v3.test.f90
@@ -39,7 +39,7 @@ contains
     subroutine init(self)
         class(write_goes_abi_ioda_v3_test_t), intent(inout) :: self
         integer :: i, j
-        character(len=100) :: output_dir
+        character(len=512) :: output_dir
 
         call get_command_argument(1, output_dir)
         if (trim(output_dir) == '') then


### PR DESCRIPTION
### Summary

This PR increases the length of the `output_dir` character variable in the `write_goes_abi_ioda_v3` test from 100 to 512 characters.

### Motivation

Previously, `output_dir` was defined with a fixed length of 100 characters. This caused truncation or runtime errors when using directory paths longer than 100 characters.
### Changes

* Updated `character(len=100) :: output_dir` to `character(len=512)` in the test program.
* No logic changes beyond this buffer size increase.
