### PR TITLE
Fix datetime assignment in GOES-ABI superobbing logic

### DIFF
--- a/src/goes_abi_converter.f90
+++ b/src/goes_abi_converter.f90
@@ -984,8 +984,7 @@ end subroutine read_GRB
             end if
 
             iloc = iloc + 1
-            write(unit=datetime(iloc), fmt='(i4,a,i2.2,a,i2.2,a,i2.2,a,i2.2,a,i2.2,a)')  &
-                  iyear, '-', imonth, '-', iday, 'T', ihour, ':', imin, ':', isec, 'Z'
+            call get_julian_time(iyear, imonth, iday, ihour, imin, isec, gstime, datetime(iloc))
 
             ! Super-ob BT for this channel
             do k = 1, nband


### PR DESCRIPTION
### Summary

This PR fixes a bug in the GOES-ABI superobbing routine where `datetime(iloc)` was incorrectly set as a formatted string instead of a long integer representing the epoch time. The code now correctly assigns a 64-bit epoch time using `get_julian_time`.
