### PR TITLE
Update `datetime` handling to use `dateTime` with correct type and fill behavior and simplify environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ The `obs2ioda-v3` executable will reside in the `bin` directory within the build
 
 ### Running the Obs2Ioda Test Suite
 #### Running the Unit Test Suite
+<<<<<<< HEAD
 1. **Run the unit test suite** using `ctest`. To see detailed output and the list of tests being executed, add the `--verbose` flag:
+=======
+1. **Run the unit test suite** using `ctest` from the `obs2ioda` build directory. To see detailed output and the list of tests being executed, add the `--verbose` flag:
+>>>>>>> 3fafb80 (Added global variables for each dimension. (#82))
    ```bash
    ctest --verbose
    ```

--- a/README.md
+++ b/README.md
@@ -37,11 +37,8 @@ The `obs2ioda-v3` executable will reside in the `bin` directory within the build
 
 ### Running the Obs2Ioda Test Suite
 #### Running the Unit Test Suite
-<<<<<<< HEAD
 1. **Run the unit test suite** using `ctest`. To see detailed output and the list of tests being executed, add the `--verbose` flag:
-=======
 1. **Run the unit test suite** using `ctest` from the `obs2ioda` build directory. To see detailed output and the list of tests being executed, add the `--verbose` flag:
->>>>>>> 3fafb80 (Added global variables for each dimension. (#82))
    ```bash
    ctest --verbose
    ```

--- a/cmake/Obs2Ioda_Test_Functions.cmake
+++ b/cmake/Obs2Ioda_Test_Functions.cmake
@@ -27,3 +27,31 @@ function(add_cxx_ctest name sources include_directories library_dependencies)
             COMMAND ${name} --gtest_filter=*
     )
 endfunction()
+
+# Adds a Fortran test executable and registers it as a CTest.
+#
+# This function creates an executable target for a Fortran test, sets up
+# library dependencies, and registers the test with CTest.
+#
+# Arguments:
+#   name                 - Name of the test executable.
+#   sources              - List of source files for the test.
+#   library_dependencies - Libraries that the test executable should link against.
+#
+# The function does the following:
+#   1. Creates an executable target with the given name and sources.
+#   3. Links the target against the specified libraries.
+#   4. Registers the executable as a CTest.
+#
+# Example usage:
+#   add_fortran_ctest(my_test "test.f90" "<library_dependencies>")
+#
+function(add_fortran_ctest name sources library_dependencies)
+    add_executable(${name} ${sources})
+    set_target_properties(${name} PROPERTIES LINKER_LANGUAGE Fortran)
+    target_link_libraries(${name} PUBLIC ${library_dependencies})
+    add_test(
+            NAME ${name}
+            COMMAND ${name}
+    )
+endfunction()

--- a/env-setup/environment.yml
+++ b/env-setup/environment.yml
@@ -1,0 +1,8 @@
+name: obs2ioda
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11  # You can change this version if needed
+  - netCDF4
+  - pytest
+  - requests

--- a/env-setup/gnu_derecho.csh
+++ b/env-setup/gnu_derecho.csh
@@ -1,0 +1,32 @@
+#!/bin/csh
+
+# Load modules
+module purge
+module load ncarenv/23.09
+module load gcc/12.2.0 
+module load netcdf/4.9.2
+module load cmake
+module load conda/latest
+
+# Check if conda is available
+if ( ! $?CONDA_EXE ) then
+    echo "Error: conda not found. Check if the 'conda/latest' module loaded correctly."
+    exit 1
+endif
+
+# Check if obs2ioda conda environment exists
+setenv HAS_ENV `conda info --envs | awk '{print $1}' | grep -x "obs2ioda"`
+
+if ( "$HAS_ENV" == "" ) then
+    echo "Creating conda environment 'obs2ioda'..."
+    conda env create -f environment.yml
+endif
+
+# Initialize conda if needed (optional if not already initialized in .cshrc)
+if ( $?CONDA_SHLVL == 0 ) then
+    source `conda info --base`/etc/profile.d/conda.csh
+endif
+
+# Activate the environment
+conda activate obs2ioda
+

--- a/env-setup/gnu_derecho.sh
+++ b/env-setup/gnu_derecho.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Load modules
+module --force purge
+module load ncarenv/23.09
+module load gcc/12.2.0
+module load netcdf/4.9.2
+module load cmake
+module load conda/latest 
+
+# Check if conda is available
+if ! command -v conda &> /dev/null; then
+    echo "Error: conda not found. Check if the 'anaconda' module loaded correctly."
+    exit 1
+fi
+
+# Check if obs2ioda conda environment exists
+if ! conda info --envs | awk '{print $1}' | grep -qx "obs2ioda"; then
+    echo "Creating conda environment 'obs2ioda'..."
+    conda env create -f environment.yml
+fi
+
+# Activate the environment
+conda activate obs2ioda
+

--- a/env-setup/intel_derecho.csh
+++ b/env-setup/intel_derecho.csh
@@ -1,0 +1,33 @@
+#!/bin/csh
+
+# Load modules
+module purge
+module load ncarenv/23.09
+module load intel-classic/2023.2.1
+module load netcdf/4.9.2
+module load cmake
+module load conda/latest
+
+# Check if conda is available
+if ( ! $?CONDA_EXE ) then
+    echo "Error: conda not found. Check if the 'conda/latest' module loaded correctly."
+    exit 1
+endif
+
+# Check if obs2ioda conda environment exists
+setenv HAS_ENV `conda info --envs | awk '{print $1}' | grep -x "obs2ioda"`
+
+if ( "$HAS_ENV" == "" ) then
+    echo "Creating conda environment 'obs2ioda'..."
+    conda env create -f environment.yml
+endif
+
+# Initialize conda if needed (optional if not already initialized in .cshrc)
+if ( $?CONDA_SHLVL == 0 ) then
+    source `conda info --base`/etc/profile.d/conda.csh
+endif
+
+# Activate the environment
+conda activate obs2ioda
+
+

--- a/env-setup/intel_derecho.sh
+++ b/env-setup/intel_derecho.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Load modules
+module --force purge
+module load ncarenv/23.09
+module load intel-classic/2023.2.1
+module load netcdf/4.9.2
+module load cmake
+module load conda/latest 
+
+# Check if conda is available
+if ! command -v conda &> /dev/null; then
+    echo "Error: conda not found. Check if the 'anaconda' module loaded correctly."
+    exit 1
+fi
+
+# Check if obs2ioda conda environment exists
+if ! conda info --envs | awk '{print $1}' | grep -qx "obs2ioda"; then
+    echo "Creating conda environment 'obs2ioda'..."
+    conda env create -f environment.yml
+fi
+
+# Activate the environment
+conda activate obs2ioda
+

--- a/src/goes_abi_converter.f90
+++ b/src/goes_abi_converter.f90
@@ -17,7 +17,7 @@ program Goes_ReBroadcast_converter
 !        /
 
    use define_mod, only:  missing_r
-   use goes_abi_converter_mod, only: write_iodav3_netcdf
+   use goes_abi_converter_mod, only: write_iodav3_netcdf, set_goes_abi_out_fname
 
    implicit none
    include 'netcdf.inc'
@@ -29,7 +29,8 @@ program Goes_ReBroadcast_converter
    integer, parameter  :: i_long   = selected_int_kind(8)   ! long integer
    integer, parameter  :: i_kind   = i_long                 ! default integer
    integer, parameter  :: r_kind   = r_single               ! default real
-   character(len=14), parameter :: BCM_id = 'CG_ABI-L2-ACMC'
+   !   character(len=14), parameter :: BCM_id = 'CG_ABI-L2-ACMC'
+   character(len=14), parameter :: BCM_id = 'OR_ABI-L2-ACMF'
 
    integer(i_kind), parameter :: nband      = 10  ! IR bands 7-16
    integer(i_kind) :: band_start = 7
@@ -342,7 +343,7 @@ program Goes_ReBroadcast_converter
 
    if ( write_iodav3 ) then
       do it = 1, ntime
-         out_fname = trim(data_id)//'_'//sat_id//'_'//time_start(it)//'.nc4'
+         call set_goes_abi_out_fname(out_fname, trim(sat_id), time_start(it))
          write(0,*) 'Writing ', trim(out_fname)
          if ( allocated(rdata(it)%cm) ) then
             call output_iodav3(trim(out_fname), time_start(it), nx, ny, nband, got_latlon, &
@@ -984,8 +985,7 @@ end subroutine read_GRB
             end if
 
             iloc = iloc + 1
-            write(unit=datetime(iloc), fmt='(i4,a,i2.2,a,i2.2,a,i2.2,a,i2.2,a,i2.2,a)')  &
-                  iyear, '-', imonth, '-', iday, 'T', ihour, ':', imin, ':', isec, 'Z'
+            call get_julian_time(iyear, imonth, iday, ihour, imin, isec, gstime, datetime(iloc))
 
             ! Super-ob BT for this channel
             do k = 1, nband

--- a/src/utils_mod.f90
+++ b/src/utils_mod.f90
@@ -9,6 +9,7 @@ private
 public :: da_advance_time
 public :: get_julian_time
 public :: da_get_time_slots
+public :: to_lower
 
 contains
 subroutine da_advance_time (date_in, dtime, date_out)
@@ -337,5 +338,35 @@ subroutine da_get_time_slots(nt,tmin,tmax,time_slots)
    end if
 
 end subroutine da_get_time_slots
+
+   ! @brief Converts a string to lowercase.
+   !
+   ! This function takes a string as input and converts all uppercase
+   ! alphabetical characters to their corresponding lowercase characters.
+   ! Non-alphabetical characters are left unchanged.
+   !
+   ! @param s The input string to be converted.
+   !          It is passed as an argument with intent(in) and remains unchanged.
+   !
+   ! @return The string in lowercase. The function returns a new string
+   !         with the same length as the input, but with all uppercase
+   !         characters converted to lowercase.
+   !
+   ! @note This function does not handle locale-specific conversions and
+   !       assumes that the characters in the string are ASCII.
+   !
+   function to_lower(s)
+      character(len=*), intent(in) :: s  ! The input string to be converted.
+      character(len=len(s)) :: to_lower  ! The output string in lowercase.
+      integer :: i  ! Loop variable.
+
+      to_lower = s  ! Initialize output string as input string.
+      do i = 1, len(s)
+         if (iachar(to_lower(i:i)) >= iachar('A') .and. iachar(to_lower(i:i)) <= iachar('Z')) then
+            ! Convert uppercase letters to lowercase.
+            to_lower(i:i) = achar(iachar(to_lower(i:i)) - iachar('A') + iachar('a'))
+         end if
+      end do
+   end function to_lower
 
 end module utils_mod

--- a/test/fortran/CMakeLists.txt
+++ b/test/fortran/CMakeLists.txt
@@ -4,13 +4,9 @@ set(test_transpose_and_flatten_SOURCES
 set(test_transpose_and_flatten_LIBRARY_DEPENDENCIES
         v3
 )
-add_executable(test_transpose_and_flatten ${test_transpose_and_flatten_SOURCES})
-target_link_libraries(test_transpose_and_flatten
-        PRIVATE
+add_fortran_ctest(test_transpose_and_flatten
+        ${test_transpose_and_flatten_SOURCES}
         ${test_transpose_and_flatten_LIBRARY_DEPENDENCIES}
-)
-add_test(NAME test_transpose_and_flatten
-        COMMAND test_transpose_and_flatten
 )
 
 set(test_get_julian_time_SOURCES
@@ -19,11 +15,28 @@ set(test_get_julian_time_SOURCES
 set(test_get_julian_time_LIBRARY_DEPENDENCIES
         v3
 )
-add_executable(test_get_julian_time ${test_get_julian_time_SOURCES})
-target_link_libraries(test_get_julian_time
-        PRIVATE
+add_fortran_ctest(test_get_julian_time
+        ${test_get_julian_time_SOURCES}
         ${test_get_julian_time_LIBRARY_DEPENDENCIES}
 )
-add_test(NAME test_get_julian_time
-        COMMAND test_get_julian_time
+set(test_to_lower_SOURCES
+        to_lower.test.f90
+)
+set(test_to_lower_LIBRARY_DEPENDENCIES
+        v3
+)
+add_fortran_ctest(test_to_lower
+        ${test_to_lower_SOURCES}
+        ${test_to_lower_LIBRARY_DEPENDENCIES}
+)
+
+set(test_set_goes_abi_out_fname_SOURCES
+        set_goes_abi_out_fname.test.f90
+)
+set(test_set_goes_abi_out_fname_LIBRARY_DEPENDENCIES
+        v3
+)
+add_fortran_ctest(test_set_goes_abi_out_fname
+        ${test_set_goes_abi_out_fname_SOURCES}
+        ${test_set_goes_abi_out_fname_LIBRARY_DEPENDENCIES}
 )

--- a/test/fortran/set_goes_abi_out_fname.test.f90
+++ b/test/fortran/set_goes_abi_out_fname.test.f90
@@ -1,0 +1,50 @@
+! @brief Unit test for the `set_goes_abi_out_fname` subroutine.
+!
+! This program tests the `set_goes_abi_out_fname` subroutine, which generates
+! the output filename based on satellite ID and the provided start time.
+program set_goes_abi_out_fname_test
+    use goes_abi_converter_mod, only: set_goes_abi_out_fname
+    implicit none
+
+    character(len=256) :: fname
+    character(len=10) :: sat_id
+    character(len=22) :: time_start
+    character(len=256) :: expected_fname
+    integer :: i
+
+    ! Test 1 - Regular satellite ID and start time
+    sat_id = "G16"
+    time_start = "2018-04-15T00:00:41.9Z"
+    expected_fname = "abi_g16_obs_2018041500_00.h5"
+    call set_goes_abi_out_fname(fname, sat_id, time_start)
+    if (.not. fname == expected_fname) then
+        print *, " FAILED"
+        print *, "  Expected: ", expected_fname
+        print *, "  Got:      ", fname
+        stop 1
+    end if
+
+    ! Test 2 - Regular satellite ID and start time with different minutes
+    sat_id = "G16"
+    time_start = "2018-04-15T00:15:41.9Z"
+    expected_fname = "abi_g16_obs_2018041500_15.h5"
+    call set_goes_abi_out_fname(fname, sat_id, time_start)
+    if (.not. fname == expected_fname) then
+        print *, " FAILED"
+        print *, "  Expected: ", expected_fname
+        print *, "  Got:      ", fname
+        stop 1
+    end if
+
+    ! Test 3 - Different satellite ID
+    sat_id = "G6"
+    time_start = "2018-04-15T00:15:41.9Z"
+    expected_fname = "abi_g6_obs_2018041500_15.h5"
+    call set_goes_abi_out_fname(fname, sat_id, time_start)
+    if (.not. fname == expected_fname) then
+        print *, " FAILED"
+        print *, "  Expected: ", expected_fname
+        print *, "  Got:      ", fname
+        stop 1
+    end if
+end program set_goes_abi_out_fname_test

--- a/test/fortran/to_lower.test.f90
+++ b/test/fortran/to_lower.test.f90
@@ -1,0 +1,45 @@
+! @brief Unit test for the `to_lower` function.
+!
+! This program tests the `to_lower` function, which converts a string to lowercase.
+! It checks if the function correctly converts input strings to lowercase for various cases:
+! - Test 1: Converting "HELLO WORLD" to "hello world".
+! - Test 2: Converting "Test123" to "test123".
+!
+! Each test compares the output of the `to_lower` function with the expected result.
+! If the output matches the expected value, the test is marked as passed. Otherwise,
+! it is marked as failed, and the program stops with an error message.
+program to_lower_test
+    use utils_mod, only: to_lower
+    implicit none
+
+    character(len=100) :: input_str, output_str, expected
+    integer :: i
+
+    ! Test 1
+    input_str = "HELLO WORLD"
+    expected = "hello world"
+    output_str = to_lower(input_str)
+
+    ! Check result for Test 1
+    if (output_str == expected) then
+        print *, "Test 1 PASSED"
+    else
+        print *, "Test 1 FAILED"
+        print *, "  Expected: ", expected
+        print *, "  Got:      ", output_str
+        stop 1
+    end if
+
+    input_str = "Test123"
+    expected = "test123"
+    output_str = to_lower(input_str)
+
+    if (output_str == expected) then
+        print *, "Test 2 PASSED"
+    else
+        print *, "Test 2 FAILED"
+        print *, "  Expected: ", expected
+        print *, "  Got:      ", output_str
+        stop 1
+    end if
+end program to_lower_test

--- a/test/validation/CMakeLists.txt
+++ b/test/validation/CMakeLists.txt
@@ -5,6 +5,7 @@ set(test_write_goes_abi_ioda_v3_LIBRARY_DEPENDENCIES
         v3
 )
 add_executable(test_write_goes_abi_ioda_v3 ${test_write_goes_abi_ioda_v3_SOURCES})
+set_target_properties(test_write_goes_abi_ioda_v3 PROPERTIES LINKER_LANGUAGE Fortran)
 target_link_libraries(test_write_goes_abi_ioda_v3
         PRIVATE
         ${test_write_goes_abi_ioda_v3_LIBRARY_DEPENDENCIES}


### PR DESCRIPTION
This PR updates the `goes_abi` converter in the `obs2ioda` library to improve compliance with the IODA v3 format and address several compilation issues.

### Changes

* **Corrected `dateTime` representation**:
  The `dateTime` variable is now written as an `int64` array representing epoch seconds for each observation, instead of as a string. This aligns with the expected format for IODA v3 files.

* **Added `dateTime` units attribute**:
  The NetCDF attribute for `dateTime` units was added (`"seconds since 1970-01-01T00:00:00Z"`), as required by the IODA v3 specification.

* **Compilation fixes**:
  Resolved various minor compilation issues, including Fortran unit tests that previously failed to compile with the Intel Fortran compiler.
  
 * **Simplified output file naming:**
The output file name now includes only the satellite ID and the date/time with minute precision. This reduces filename verbosity, making the files more straightforward to work with in scripts and data workflows.

* **Added a conda environment yaml for building the Python testing environment**
The conda environment file makes creating a conda environment for running the test suite seamlessly.
